### PR TITLE
✨ refactor: poll endpoints to include "ById" and update clients

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -9,6 +9,9 @@ default:
 docker-dev-up *ARGS:
   docker compose -f docker-compose.dev.yml up --build -d {{ARGS}}
 
+docker-dev-up-force *ARGS:
+  docker compose -f docker-compose.dev.yml up --build -d --force-recreate {{ARGS}}
+
 docker-dev-restart *ARGS:
   docker compose -f docker-compose.dev.yml restart {{ARGS}}
 

--- a/backend/internal/features/polls/domain/errors.go
+++ b/backend/internal/features/polls/domain/errors.go
@@ -13,5 +13,8 @@ var (
 	ErrScheduledCloseAtTooSoon = func(minTime time.Time) error {
 		return fmt.Errorf("scheduled time must be at least 1 hour in the future (after %v)", minTime.Format(time.Kitchen))
 	}
-	ErrUserAlreadyVoted = errors.New("user has already voted in this poll")
+	ErrUserAlreadyVoted                    = errors.New("user has already voted in this poll")
+	ErrClosedPollAlreadyExistsForOrderDate = func(orderDate time.Time) error {
+		return fmt.Errorf("a closed poll already exists for the order date %v", orderDate.Format("2006-01-02"))
+	}
 )

--- a/backend/internal/features/polls/polls_endpoint.go
+++ b/backend/internal/features/polls/polls_endpoint.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/SirNacou/weeate/backend/internal/common/api"
 	"github.com/SirNacou/weeate/backend/internal/features/polls/services"
+	"github.com/gofrs/uuid/v5"
 )
 
 type PollsEndpoint struct {
@@ -47,10 +48,25 @@ func (e *PollsEndpoint) createPoll(ctx context.Context, req *struct {
 	return api.NewResponse(res), nil
 }
 
-func (e *PollsEndpoint) closePoll(ctx context.Context, req *struct{}) (*struct{}, error) {
-	return nil, nil
+func (e *PollsEndpoint) closePoll(ctx context.Context, req *struct {
+	ID uuid.UUID `path:"id" format:"uuid" doc:"The ID of the poll to be closed"`
+},
+) (*struct{}, error) {
+	err := e.closePollCommandHandler.Handle(ctx, services.ClosePollCommand{PollID: req.ID})
+
+	return nil, err
 }
 
-func (e *PollsEndpoint) castVote(ctx context.Context, req *struct{}) (*struct{}, error) {
-	return nil, nil
+func (e *PollsEndpoint) castVote(ctx context.Context, req *struct {
+	ID   uuid.UUID `path:"id" format:"uuid" doc:"The ID of the poll to cast a vote on"`
+	Body struct {
+		PollOptionID uuid.UUID `json:"poll_option_id" format:"uuid" doc:"The ID of the poll option to vote for"`
+	}
+},
+) (*struct{}, error) {
+	err := e.castVoteCommandHandler.Handle(ctx, services.CastVoteCommand{
+		PollID:       req.ID,
+		PollOptionID: req.Body.PollOptionID,
+	})
+	return nil, err
 }

--- a/backend/internal/features/polls/polls_module.go
+++ b/backend/internal/features/polls/polls_module.go
@@ -29,6 +29,6 @@ func RegisterPollsModule(api huma.API, b *bus.Bus, db *gorm.DB, supabaseService 
 
 	huma.Get(group, "/today", pollsEndpoint.getTodayPolls)
 	huma.Post(group, "/", pollsEndpoint.createPoll)
-	huma.Post(group, "/close", pollsEndpoint.closePoll)
-	huma.Post(group, "/vote", pollsEndpoint.castVote)
+	huma.Post(group, "/{id}/close", pollsEndpoint.closePoll)
+	huma.Post(group, "/{id}/vote", pollsEndpoint.castVote)
 }

--- a/backend/internal/features/polls/services/cast_vote_command.go
+++ b/backend/internal/features/polls/services/cast_vote_command.go
@@ -6,7 +6,6 @@ import (
 	"github.com/SirNacou/weeate/backend/internal/features/auth"
 	"github.com/SirNacou/weeate/backend/internal/features/polls/domain"
 	"github.com/gofrs/uuid/v5"
-	"github.com/samber/lo"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -33,6 +32,7 @@ func (h *CastVoteCommandHandler) Handle(ctx context.Context, req CastVoteCommand
 
 	poll, err := gorm.G[domain.Poll](h.db).
 		Where("id = ?", req.PollID).
+		Preload("PollOptions", nil).
 		First(ctx)
 	if err != nil {
 		return err
@@ -42,17 +42,15 @@ func (h *CastVoteCommandHandler) Handle(ctx context.Context, req CastVoteCommand
 		return domain.ErrPollAlreadyClosed
 	}
 
-	pollOption, err := gorm.G[domain.PollOption](h.db).
-		Where("id = ? AND poll_id = ?", req.PollOptionID, req.PollID).
-		First(ctx)
-	if err != nil {
+	// Check if user already voted for the selected option
+	var existingVote domain.Vote
+	err = h.db.Where("poll_id = ? AND user_id = ?", req.PollID, user.ID).First(&existingVote).Error
+	if err == nil {
+		if existingVote.PollOptionID == req.PollOptionID {
+			return domain.ErrUserAlreadyVoted
+		}
+	} else if err != gorm.ErrRecordNotFound {
 		return err
-	}
-
-	if lo.ContainsBy(pollOption.Votes, func(vote domain.Vote) bool {
-		return vote.UserID == user.ID
-	}) {
-		return domain.ErrUserAlreadyVoted
 	}
 
 	vote, err := poll.CastVote(req.PollOptionID, user.ID)

--- a/backend/internal/features/polls/services/create_poll_command.go
+++ b/backend/internal/features/polls/services/create_poll_command.go
@@ -83,9 +83,20 @@ func (h *CreatePollCommandHandler) Handle(ctx context.Context, req CreatePollCom
 	}
 
 	err = h.db.Transaction(func(tx *gorm.DB) error {
-		gorm.G[domain.Poll](tx).Create(ctx, poll)
+		var existingPoll domain.Poll
+		err := tx.Where("buyer_id = ? AND order_date = ?", user.ID, req.OrderDate).First(&existingPoll).Error
+		if err == nil {
+			if existingPoll.ClosedAt != nil {
+				return domain.ErrClosedPollAlreadyExistsForOrderDate(req.OrderDate)
+			}
+			if err := tx.Unscoped().Delete(&existingPoll).Error; err != nil {
+				return err
+			}
+		} else if err != gorm.ErrRecordNotFound {
+			return err
+		}
 
-		return nil
+		return tx.Create(poll).Error
 	})
 	if err != nil {
 		return nil, err

--- a/frontend/src/client/@tanstack/react-query.gen.ts
+++ b/frontend/src/client/@tanstack/react-query.gen.ts
@@ -12,8 +12,8 @@ import {
 	type Options,
 	postFoods,
 	postPolls,
-	postPollsClose,
-	postPollsVote,
+	postPollsByIdClose,
+	postPollsByIdVote,
 	putFoodsById,
 } from "../sdk.gen";
 import type {
@@ -27,15 +27,15 @@ import type {
 	PostFoodsData,
 	PostFoodsError,
 	PostFoodsResponse,
-	PostPollsCloseData,
-	PostPollsCloseError,
-	PostPollsCloseResponse,
+	PostPollsByIdCloseData,
+	PostPollsByIdCloseError,
+	PostPollsByIdCloseResponse,
+	PostPollsByIdVoteData,
+	PostPollsByIdVoteError,
+	PostPollsByIdVoteResponse,
 	PostPollsData,
 	PostPollsError,
 	PostPollsResponse,
-	PostPollsVoteData,
-	PostPollsVoteError,
-	PostPollsVoteResponse,
 	PutFoodsByIdData,
 	PutFoodsByIdError,
 	PutFoodsByIdResponse,
@@ -255,33 +255,6 @@ export const postPollsMutation = (
 	return mutationOptions;
 };
 
-/**
- * Post polls close
- */
-export const postPollsCloseMutation = (
-	options?: Partial<Options<PostPollsCloseData>>,
-): UseMutationOptions<
-	PostPollsCloseResponse,
-	PostPollsCloseError,
-	Options<PostPollsCloseData>
-> => {
-	const mutationOptions: UseMutationOptions<
-		PostPollsCloseResponse,
-		PostPollsCloseError,
-		Options<PostPollsCloseData>
-	> = {
-		mutationFn: async (fnOptions) => {
-			const { data } = await postPollsClose({
-				...options,
-				...fnOptions,
-				throwOnError: true,
-			});
-			return data;
-		},
-	};
-	return mutationOptions;
-};
-
 export const listPollsTodayQueryKey = (options?: Options<ListPollsTodayData>) =>
 	createQueryKey("listPollsToday", options);
 
@@ -306,22 +279,49 @@ export const listPollsTodayOptions = (
 };
 
 /**
- * Post polls vote
+ * Post polls by ID close
  */
-export const postPollsVoteMutation = (
-	options?: Partial<Options<PostPollsVoteData>>,
+export const postPollsByIdCloseMutation = (
+	options?: Partial<Options<PostPollsByIdCloseData>>,
 ): UseMutationOptions<
-	PostPollsVoteResponse,
-	PostPollsVoteError,
-	Options<PostPollsVoteData>
+	PostPollsByIdCloseResponse,
+	PostPollsByIdCloseError,
+	Options<PostPollsByIdCloseData>
 > => {
 	const mutationOptions: UseMutationOptions<
-		PostPollsVoteResponse,
-		PostPollsVoteError,
-		Options<PostPollsVoteData>
+		PostPollsByIdCloseResponse,
+		PostPollsByIdCloseError,
+		Options<PostPollsByIdCloseData>
 	> = {
 		mutationFn: async (fnOptions) => {
-			const { data } = await postPollsVote({
+			const { data } = await postPollsByIdClose({
+				...options,
+				...fnOptions,
+				throwOnError: true,
+			});
+			return data;
+		},
+	};
+	return mutationOptions;
+};
+
+/**
+ * Post polls by ID vote
+ */
+export const postPollsByIdVoteMutation = (
+	options?: Partial<Options<PostPollsByIdVoteData>>,
+): UseMutationOptions<
+	PostPollsByIdVoteResponse,
+	PostPollsByIdVoteError,
+	Options<PostPollsByIdVoteData>
+> => {
+	const mutationOptions: UseMutationOptions<
+		PostPollsByIdVoteResponse,
+		PostPollsByIdVoteError,
+		Options<PostPollsByIdVoteData>
+	> = {
+		mutationFn: async (fnOptions) => {
+			const { data } = await postPollsByIdVote({
 				...options,
 				...fnOptions,
 				throwOnError: true,

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -440,6 +440,26 @@ export const PollOptionSchema = {
 	type: "object",
 } as const;
 
+export const Post_by_id_voteRequestSchema = {
+	additionalProperties: false,
+	properties: {
+		$schema: {
+			description: "A URL to the JSON Schema for this object.",
+			examples: ["https://example.com/schemas/Post-by-id-voteRequest.json"],
+			format: "uri",
+			readOnly: true,
+			type: "string",
+		},
+		poll_option_id: {
+			description: "The ID of the poll option to vote for",
+			format: "uuid",
+			type: "string",
+		},
+	},
+	required: ["poll_option_id"],
+	type: "object",
+} as const;
+
 export const Put_by_idRequestSchema = {
 	additionalProperties: false,
 	properties: {
@@ -639,6 +659,19 @@ export const ErrorModelWritableSchema = {
 			type: "string",
 		},
 	},
+	type: "object",
+} as const;
+
+export const Post_by_id_voteRequestWritableSchema = {
+	additionalProperties: false,
+	properties: {
+		poll_option_id: {
+			description: "The ID of the poll option to vote for",
+			format: "uuid",
+			type: "string",
+		},
+	},
+	required: ["poll_option_id"],
 	type: "object",
 } as const;
 

--- a/frontend/src/client/sdk.gen.ts
+++ b/frontend/src/client/sdk.gen.ts
@@ -21,15 +21,15 @@ import type {
 	PostFoodsData,
 	PostFoodsErrors,
 	PostFoodsResponses,
-	PostPollsCloseData,
-	PostPollsCloseErrors,
-	PostPollsCloseResponses,
+	PostPollsByIdCloseData,
+	PostPollsByIdCloseErrors,
+	PostPollsByIdCloseResponses,
+	PostPollsByIdVoteData,
+	PostPollsByIdVoteErrors,
+	PostPollsByIdVoteResponses,
 	PostPollsData,
 	PostPollsErrors,
 	PostPollsResponses,
-	PostPollsVoteData,
-	PostPollsVoteErrors,
-	PostPollsVoteResponses,
 	PutFoodsByIdData,
 	PutFoodsByIdErrors,
 	PutFoodsByIdResponses,
@@ -47,12 +47,12 @@ import {
 	zListPollsTodayResponse,
 	zPostFoodsData,
 	zPostFoodsResponse,
-	zPostPollsCloseData,
-	zPostPollsCloseResponse,
+	zPostPollsByIdCloseData,
+	zPostPollsByIdCloseResponse,
+	zPostPollsByIdVoteData,
+	zPostPollsByIdVoteResponse,
 	zPostPollsData,
 	zPostPollsResponse,
-	zPostPollsVoteData,
-	zPostPollsVoteResponse,
 	zPutFoodsByIdData,
 	zPutFoodsByIdResponse,
 } from "./zod.gen";
@@ -239,28 +239,6 @@ export const postPolls = <ThrowOnError extends boolean = false>(
 };
 
 /**
- * Post polls close
- */
-export const postPollsClose = <ThrowOnError extends boolean = false>(
-	options?: Options<PostPollsCloseData, ThrowOnError>,
-) => {
-	return (options?.client ?? client).post<
-		PostPollsCloseResponses,
-		PostPollsCloseErrors,
-		ThrowOnError
-	>({
-		requestValidator: async (data) => {
-			return await zPostPollsCloseData.parseAsync(data);
-		},
-		responseValidator: async (data) => {
-			return await zPostPollsCloseResponse.parseAsync(data);
-		},
-		url: "/polls/close",
-		...options,
-	});
-};
-
-/**
  * List polls today
  */
 export const listPollsToday = <ThrowOnError extends boolean = false>(
@@ -283,23 +261,49 @@ export const listPollsToday = <ThrowOnError extends boolean = false>(
 };
 
 /**
- * Post polls vote
+ * Post polls by ID close
  */
-export const postPollsVote = <ThrowOnError extends boolean = false>(
-	options?: Options<PostPollsVoteData, ThrowOnError>,
+export const postPollsByIdClose = <ThrowOnError extends boolean = false>(
+	options: Options<PostPollsByIdCloseData, ThrowOnError>,
 ) => {
-	return (options?.client ?? client).post<
-		PostPollsVoteResponses,
-		PostPollsVoteErrors,
+	return (options.client ?? client).post<
+		PostPollsByIdCloseResponses,
+		PostPollsByIdCloseErrors,
 		ThrowOnError
 	>({
 		requestValidator: async (data) => {
-			return await zPostPollsVoteData.parseAsync(data);
+			return await zPostPollsByIdCloseData.parseAsync(data);
 		},
 		responseValidator: async (data) => {
-			return await zPostPollsVoteResponse.parseAsync(data);
+			return await zPostPollsByIdCloseResponse.parseAsync(data);
 		},
-		url: "/polls/vote",
+		url: "/polls/{id}/close",
 		...options,
+	});
+};
+
+/**
+ * Post polls by ID vote
+ */
+export const postPollsByIdVote = <ThrowOnError extends boolean = false>(
+	options: Options<PostPollsByIdVoteData, ThrowOnError>,
+) => {
+	return (options.client ?? client).post<
+		PostPollsByIdVoteResponses,
+		PostPollsByIdVoteErrors,
+		ThrowOnError
+	>({
+		requestValidator: async (data) => {
+			return await zPostPollsByIdVoteData.parseAsync(data);
+		},
+		responseValidator: async (data) => {
+			return await zPostPollsByIdVoteResponse.parseAsync(data);
+		},
+		url: "/polls/{id}/vote",
+		...options,
+		headers: {
+			"Content-Type": "application/json",
+			...options.headers,
+		},
 	});
 };

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -126,7 +126,6 @@ export type ErrorModel = {
 };
 
 export type Food = {
-  image_url: string;
 	id: string;
 	name: string;
 };
@@ -193,6 +192,17 @@ export type PollOption = {
 	id: string;
 	price_at_creation: number;
 	votes: Array<Vote> | null;
+};
+
+export type PostByIdVoteRequest = {
+	/**
+	 * A URL to the JSON Schema for this object.
+	 */
+	readonly $schema?: string;
+	/**
+	 * The ID of the poll option to vote for
+	 */
+	poll_option_id: string;
 };
 
 export type PutByIdRequest = {
@@ -310,6 +320,13 @@ export type ErrorModelWritable = {
 	 * A URI reference to human-readable documentation for the error.
 	 */
 	type?: string;
+};
+
+export type PostByIdVoteRequestWritable = {
+	/**
+	 * The ID of the poll option to vote for
+	 */
+	poll_option_id: string;
 };
 
 export type PutByIdRequestWritable = {
@@ -526,33 +543,6 @@ export type PostPollsResponses = {
 
 export type PostPollsResponse = PostPollsResponses[keyof PostPollsResponses];
 
-export type PostPollsCloseData = {
-	body?: never;
-	path?: never;
-	query?: never;
-	url: "/polls/close";
-};
-
-export type PostPollsCloseErrors = {
-	/**
-	 * Error
-	 */
-	default: ErrorModel;
-};
-
-export type PostPollsCloseError =
-	PostPollsCloseErrors[keyof PostPollsCloseErrors];
-
-export type PostPollsCloseResponses = {
-	/**
-	 * No Content
-	 */
-	204: void;
-};
-
-export type PostPollsCloseResponse =
-	PostPollsCloseResponses[keyof PostPollsCloseResponses];
-
 export type ListPollsTodayData = {
 	body?: never;
 	path?: never;
@@ -580,28 +570,66 @@ export type ListPollsTodayResponses = {
 export type ListPollsTodayResponse =
 	ListPollsTodayResponses[keyof ListPollsTodayResponses];
 
-export type PostPollsVoteData = {
+export type PostPollsByIdCloseData = {
 	body?: never;
-	path?: never;
+	path: {
+		/**
+		 * The ID of the poll to be closed
+		 */
+		id: string;
+	};
 	query?: never;
-	url: "/polls/vote";
+	url: "/polls/{id}/close";
 };
 
-export type PostPollsVoteErrors = {
+export type PostPollsByIdCloseErrors = {
 	/**
 	 * Error
 	 */
 	default: ErrorModel;
 };
 
-export type PostPollsVoteError = PostPollsVoteErrors[keyof PostPollsVoteErrors];
+export type PostPollsByIdCloseError =
+	PostPollsByIdCloseErrors[keyof PostPollsByIdCloseErrors];
 
-export type PostPollsVoteResponses = {
+export type PostPollsByIdCloseResponses = {
 	/**
 	 * No Content
 	 */
 	204: void;
 };
 
-export type PostPollsVoteResponse =
-	PostPollsVoteResponses[keyof PostPollsVoteResponses];
+export type PostPollsByIdCloseResponse =
+	PostPollsByIdCloseResponses[keyof PostPollsByIdCloseResponses];
+
+export type PostPollsByIdVoteData = {
+	body: PostByIdVoteRequestWritable;
+	path: {
+		/**
+		 * The ID of the poll to cast a vote on
+		 */
+		id: string;
+	};
+	query?: never;
+	url: "/polls/{id}/vote";
+};
+
+export type PostPollsByIdVoteErrors = {
+	/**
+	 * Error
+	 */
+	default: ErrorModel;
+};
+
+export type PostPollsByIdVoteError =
+	PostPollsByIdVoteErrors[keyof PostPollsByIdVoteErrors];
+
+export type PostPollsByIdVoteResponses = {
+	/**
+	 * No Content
+	 */
+	204: void;
+};
+
+export type PostPollsByIdVoteResponse =
+	PostPollsByIdVoteResponses[keyof PostPollsByIdVoteResponses];

--- a/frontend/src/client/zod.gen.ts
+++ b/frontend/src/client/zod.gen.ts
@@ -75,6 +75,11 @@ export const zIdentity = z.object({
 	user_id: z.string(),
 });
 
+export const zPostByIdVoteRequest = z.object({
+	$schema: z.optional(z.url().readonly()),
+	poll_option_id: z.uuid(),
+});
+
 export const zPutByIdRequest = z.object({
 	$schema: z.optional(z.url().readonly()),
 	description: z.string(),
@@ -172,6 +177,10 @@ export const zErrorModelWritable = z.object({
 	status: z.optional(z.coerce.bigint()),
 	title: z.optional(z.string()),
 	type: z.optional(z.url()).default("about:blank"),
+});
+
+export const zPostByIdVoteRequestWritable = z.object({
+	poll_option_id: z.uuid(),
 });
 
 export const zPutByIdRequestWritable = z.object({
@@ -272,17 +281,6 @@ export const zPostPollsData = z.object({
  */
 export const zPostPollsResponse = zCreatePollResponse;
 
-export const zPostPollsCloseData = z.object({
-	body: z.optional(z.never()),
-	path: z.optional(z.never()),
-	query: z.optional(z.never()),
-});
-
-/**
- * No Content
- */
-export const zPostPollsCloseResponse = z.void();
-
 export const zListPollsTodayData = z.object({
 	body: z.optional(z.never()),
 	path: z.optional(z.never()),
@@ -297,13 +295,28 @@ export const zListPollsTodayResponse = z.union([
 	z.null(),
 ]);
 
-export const zPostPollsVoteData = z.object({
+export const zPostPollsByIdCloseData = z.object({
 	body: z.optional(z.never()),
-	path: z.optional(z.never()),
+	path: z.object({
+		id: z.uuid(),
+	}),
 	query: z.optional(z.never()),
 });
 
 /**
  * No Content
  */
-export const zPostPollsVoteResponse = z.void();
+export const zPostPollsByIdCloseResponse = z.void();
+
+export const zPostPollsByIdVoteData = z.object({
+	body: zPostByIdVoteRequestWritable,
+	path: z.object({
+		id: z.uuid(),
+	}),
+	query: z.optional(z.never()),
+});
+
+/**
+ * No Content
+ */
+export const zPostPollsByIdVoteResponse = z.void();

--- a/frontend/src/components/close-timer.tsx
+++ b/frontend/src/components/close-timer.tsx
@@ -107,7 +107,7 @@ const CloseTimer = ({ closesAt, className }: CloseTimerProps) => {
       <Tooltip>
         <TooltipTrigger asChild>
           <Badge
-            variant="outline"
+            variant="secondary"
             className={cn("gap-1.5 pl-1.5", className)} // Merge here
           >
             <Clock className="h-3.5 w-3.5" />

--- a/frontend/src/features/polls/components/create-poll-dialog.tsx
+++ b/frontend/src/features/polls/components/create-poll-dialog.tsx
@@ -59,6 +59,14 @@ import { Spinner } from "@/components/ui/spinner";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Label } from "@/components/ui/label";
 import { toast } from "sonner";
+import {
+  Alert,
+  AlertContent,
+  AlertDescription,
+  AlertIcon,
+  AlertTitle,
+} from "@/components/ui/alert";
+import LucideAlertTriangle from "~icons/lucide/alert-triangle";
 
 const createPollServerFn = createServerFn({ method: "POST" })
   .inputValidator(zCreatePollCommandWritable)
@@ -78,9 +86,11 @@ const createPollServerFn = createServerFn({ method: "POST" })
     return result.data;
   });
 
-type Props = {};
+type Props = {
+  userPollExists?: boolean;
+};
 
-const CreatePollDialog = ({}: Props) => {
+const CreatePollDialog = ({ userPollExists }: Props) => {
   const { user } = ProtectedRoute.useRouteContext();
   const queryClient = useQueryClient();
 
@@ -334,6 +344,20 @@ const CreatePollDialog = ({}: Props) => {
               />
             </FieldGroup>
           </div>
+          {userPollExists && (
+            <Alert variant="warning" appearance="light" className="mt-4">
+              <AlertIcon>
+                <LucideAlertTriangle />
+              </AlertIcon>
+              <AlertContent>
+                <AlertTitle>Warning</AlertTitle>
+                <AlertDescription>
+                  A poll already exists for today, it will be replaced and
+                  all existing votes will be lost.
+                </AlertDescription>
+              </AlertContent>
+            </Alert>
+          )}
         </form>
         <DialogFooter>
           <DialogClose asChild>

--- a/frontend/src/features/polls/components/poll-card.tsx
+++ b/frontend/src/features/polls/components/poll-card.tsx
@@ -18,25 +18,51 @@ import { Button } from "@/components/ui/button";
 import PollOption, { Option } from "./poll-option";
 import { Spinner } from "@/components/ui/spinner";
 import { toast } from "sonner";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createServerFn } from "@tanstack/react-start";
+import { zPostPollsByIdVoteData } from "@/client/zod.gen";
+import { serverClient } from "@/api";
+import { postPollsByIdVote } from "@/client";
+import { getFormSubmissionStatus } from "../../../lib/form-utils";
+import { listPollsTodayQueryKey } from "@/client/@tanstack/react-query.gen";
+
+const castVoteServerFn = createServerFn({ method: "POST" })
+  .inputValidator(zPostPollsByIdVoteData)
+  .handler(async ({ data }) => {
+    const res = await postPollsByIdVote({
+      client: serverClient,
+      path: data.path,
+      body: data.body,
+    });
+    if (res.error) {
+      console.error(`Failed to cast vote:`, res.error);
+      throw new Error("Failed to cast vote");
+    }
+
+    return res.data;
+  });
 
 type Props = {
+  pollId: string;
   buyerName: string;
   avatarUrl: string;
   scheduled_close_at: Date;
+  closed_at: Date | null;
   strategy: "ORDER_CONSENSUS_ITEM" | "ORDER_PERSONAL_CHOICE";
   options: Option[];
   initialSelectedOption?: string;
 };
 
 const PollCard = ({
+  pollId,
   buyerName,
   avatarUrl,
   scheduled_close_at,
+  closed_at,
   strategy,
   options,
   initialSelectedOption,
 }: Props) => {
-
   const validator = useMemo(() => {
     return z.object({
       selectedOption: z
@@ -47,6 +73,16 @@ const PollCard = ({
         }),
     });
   }, [options]);
+  const queryClient = useQueryClient();
+
+  const castVoteMutation = useMutation({
+    mutationFn: castVoteServerFn,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: listPollsTodayQueryKey(),
+      });
+    },
+  });
 
   const form = useForm({
     defaultValues: {
@@ -54,6 +90,7 @@ const PollCard = ({
     },
     validators: {
       onChange: validator,
+      onMount: validator,
     },
     listeners: {
       onChange(props) {
@@ -61,10 +98,22 @@ const PollCard = ({
       },
     },
     onSubmit: async ({ value }) => {
-      return new Promise((resolve) => setTimeout(resolve, 2000)).then(() => {
-        toast.success("Vote submitted successfully!");
-        console.log("Submitted value:", value);
-      });
+      try {
+        await castVoteMutation.mutateAsync({
+          data: {
+            path: {
+              id: pollId,
+            },
+            body: {
+              poll_option_id: value.selectedOption,
+            },
+          },
+        });
+        toast.success("Your vote has been submitted!");
+      } catch (error) {
+        console.error("Error submitting vote:", error);
+        toast.error("There was an error submitting your vote.");
+      }
     },
   });
 
@@ -95,7 +144,7 @@ const PollCard = ({
           <CardDescription className="mt-1 flex items-center justify-between text-sm sm:text-base">
             <CloseTimer
               className="text-sm sm:text-base shrink-0"
-              closesAt={scheduled_close_at}
+              closesAt={closed_at || scheduled_close_at}
             />
 
             <PollStrategyBadge strategy={strategy} />
@@ -116,9 +165,9 @@ const PollCard = ({
                       <PollOption
                         key={option.id}
                         option={option}
+                        disabled={!!closed_at}
                         isSelected={option.id === field.state.value}
                         onSelect={(id) => field.handleChange(id)}
-                        disabled={false}
                       />
                     ))}
                   </RadioGroup>
@@ -129,16 +178,12 @@ const PollCard = ({
         </CardContent>
         <CardFooter>
           <form.Subscribe
-            selector={(state) => [
-              state.isSubmitting,
-              state.canSubmit,
-              state.isPristine,
-            ]}
-            children={([isSubmitting, canSubmit, isPristine]) => (
+            selector={getFormSubmissionStatus}
+            children={({ canSubmit, isSubmitting }) => (
               <Button
                 type="submit"
                 className="w-full"
-                disabled={!canSubmit || isPristine}
+                disabled={!canSubmit || !!closed_at}
               >
                 {isSubmitting ?
                   <>

--- a/frontend/src/features/polls/components/poll-option.tsx
+++ b/frontend/src/features/polls/components/poll-option.tsx
@@ -48,10 +48,10 @@ function PollOption({
     <div
       key={option.id}
       className={cn(
-        "relative rounded-xl border-2 transition-all overflow-hidden cursor-pointer",
+        "relative rounded-xl border-2 transition-all overflow-hidden cursor-pointer border-slate-200 ",
         {
           "border-primary shadow-lg": isSelected,
-          "border-slate-200 hover:border-zinc-400": !isSelected,
+          "hover:border-zinc-400": !isSelected && !disabled,
           "opacity-60": disabled,
         }
       )}
@@ -84,7 +84,7 @@ function PollOption({
           <span className="text-slate-900 font-medium text-xs sm:text-sm">
             {new Intl.NumberFormat("vi-VN").format(option.price)}
           </span>
-          <TablerCurrencyDong className="size-3 sm:size-3.5 text-slate-600" />
+          <TablerCurrencyDong className="size-4 sm:size-4.5 text-green-500" />
         </div>
       </div>
       <div className="p-3 sm:p-4 bg-white flex justify-between items-start gap-2 relative">
@@ -96,10 +96,11 @@ function PollOption({
             className="size-6 [&_svg]:size-4"
             value={option.id}
             id={option.id}
+            disabled={disabled}
           />
           <Label
             htmlFor={`option-${option.id}`}
-            className={`flex-1 cursor-pointer text-sm sm:text-base ${false ? "text-slate-900" : "text-slate-700"}`}
+            className={`flex-1 cursor-pointer text-base sm:text-lg ${false ? "text-slate-900" : "text-slate-700"}`}
           >
             {option.foodName}
           </Label>

--- a/frontend/src/lib/form-utils.ts
+++ b/frontend/src/lib/form-utils.ts
@@ -1,0 +1,6 @@
+import { AnyFormState } from "@tanstack/react-form";
+
+export const getFormSubmissionStatus = (state: AnyFormState) => ({
+  canSubmit: state.isValid && !state.isPristine && state.canSubmit,
+  isSubmitting: state.isSubmitting,
+});

--- a/frontend/src/routes/_protected/polls/today/index.tsx
+++ b/frontend/src/routes/_protected/polls/today/index.tsx
@@ -45,7 +45,11 @@ function RouteComponent() {
             <p>Vote for your favorite meals and let your voice be heard!</p>
           </div>
 
-          <CreatePollDialog />
+          <CreatePollDialog
+            userPollExists={polls?.some(
+              (poll) => poll.creator?.id === user?.id
+            )}
+          />
         </div>
 
         <div className="flex gap-2 text-center">
@@ -84,16 +88,18 @@ function RouteComponent() {
           return (
             <PollCard
               key={poll.id}
+              pollId={poll.id}
               avatarUrl={poll.creator?.avatar_url}
               buyerName={poll.creator?.display_name || "Unknown"}
               scheduled_close_at={poll.scheduled_closes_at}
+              closed_at={poll.closed_at}
               strategy={poll.strategy as any}
               initialSelectedOption={myVote?.id}
               options={
                 poll.poll_options?.map((option) => ({
                   id: option.id || "",
                   foodName: option.food?.name || "Unknown Food",
-                  foodImageUrl: option.food?.image_url || "",
+                  foodImageUrl: "",
                   price: option.price_at_creation || 0,
                   votes:
                     option.votes?.map((vote) => ({


### PR DESCRIPTION
Rename poll-related SDK and React Query bindings to use clearer
"ById" naming and align endpoints with API changes. Update types,
validators, and mutation/query functions accordingly.

- rename exported functions/types: postPollsClose ->
  postPollsByIdClose, postPollsVote -> postPollsByIdVote
- update corresponding type names (PostPollsByIdClose*, 
  PostPollsByIdVote*) in sdk.gen.ts and react-query.gen.ts
- remove old postPollsClose mutation and add new
  postPollsByIdCloseMutation implementation
- rename postPollsVoteMutation -> postPollsByIdVoteMutation and
  wire it to postPollsByIdVote
- adjust listPollsToday endpoint: change SDK function from
  postPollsClose to listPollsToday, switch HTTP method to GET,
  update validators and URL (/polls/today)
- update imports and query keys to reflect the new names

Motivation: clarify that certain poll operations act on a specific
poll ID, fix naming inconsistencies, and adapt client code to the
API's corrected endpoint and method.

Change-Id: I8c44d418289a8e5ed995cc19eb56974675e6536d