### PR TITLE
✨ feat(route add protected route context and pageTitle support

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "frontend",
@@ -92,6 +91,8 @@
         "@vitejs/plugin-react": "^5.0.4",
         "babel-plugin-react-compiler": "^1.0.0",
         "jsdom": "^27.0.0",
+        "prettier": "^3.6.2",
+        "prettier-plugin-tailwindcss": "^0.7.1",
         "typescript": "^5.7.2",
         "unplugin-icons": "^22.5.0",
         "vite": "^7.1.7",
@@ -1300,6 +1301,8 @@
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
 
     "prettier": ["prettier@3.6.2", "", { "bin": "bin/prettier.cjs" }, "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ=="],
+
+    "prettier-plugin-tailwindcss": ["prettier-plugin-tailwindcss@0.7.1", "", { "peerDependencies": { "@ianvs/prettier-plugin-sort-imports": "*", "@prettier/plugin-hermes": "*", "@prettier/plugin-oxc": "*", "@prettier/plugin-pug": "*", "@shopify/prettier-plugin-liquid": "*", "@trivago/prettier-plugin-sort-imports": "*", "@zackad/prettier-plugin-twig": "*", "prettier": "^3.0", "prettier-plugin-astro": "*", "prettier-plugin-css-order": "*", "prettier-plugin-jsdoc": "*", "prettier-plugin-marko": "*", "prettier-plugin-multiline-arrays": "*", "prettier-plugin-organize-attributes": "*", "prettier-plugin-organize-imports": "*", "prettier-plugin-sort-imports": "*", "prettier-plugin-svelte": "*" }, "optionalPeers": ["@ianvs/prettier-plugin-sort-imports", "@prettier/plugin-hermes", "@prettier/plugin-oxc", "@prettier/plugin-pug", "@shopify/prettier-plugin-liquid", "@trivago/prettier-plugin-sort-imports", "@zackad/prettier-plugin-twig", "prettier-plugin-astro", "prettier-plugin-css-order", "prettier-plugin-jsdoc", "prettier-plugin-marko", "prettier-plugin-multiline-arrays", "prettier-plugin-organize-attributes", "prettier-plugin-organize-imports", "prettier-plugin-sort-imports", "prettier-plugin-svelte"] }, "sha512-Bzv1LZcuiR1Sk02iJTS1QzlFNp/o5l2p3xkopwOrbPmtMeh3fK9rVW5M3neBQzHq+kGKj/4LGQMTNcTH4NGPtQ=="],
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -102,6 +102,8 @@
     "@vitejs/plugin-react": "^5.0.4",
     "babel-plugin-react-compiler": "^1.0.0",
     "jsdom": "^27.0.0",
+    "prettier": "^3.6.2",
+    "prettier-plugin-tailwindcss": "^0.7.1",
     "typescript": "^5.7.2",
     "unplugin-icons": "^22.5.0",
     "vite": "^7.1.7",

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -267,24 +267,24 @@ export const GetFoodsQueryResponseSchema = {
 export const GetTodayOrdersResponseSchema = {
 	additionalProperties: false,
 	properties: {
-		Buyer: {
+		buyer: {
 			$ref: "#/components/schemas/UserProfile",
 		},
-		OrderItems: {
+		order_items: {
 			items: {
 				$ref: "#/components/schemas/OrderItem",
 			},
 			type: ["array", "null"],
 		},
-		PollID: {
+		poll_id: {
 			type: "string",
 		},
-		TotalPrice: {
+		total_price: {
 			format: "int64",
 			type: "integer",
 		},
 	},
-	required: ["PollID", "Buyer", "TotalPrice", "OrderItems"],
+	required: ["poll_id", "buyer", "total_price", "order_items"],
 	type: "object",
 } as const;
 
@@ -399,39 +399,39 @@ export const IdentityDataSchema = {
 export const OrderItemSchema = {
 	additionalProperties: false,
 	properties: {
-		Details: {
+		details: {
 			items: {
 				$ref: "#/components/schemas/OrderItemDetail",
 			},
 			type: ["array", "null"],
 		},
-		FoodImageUrl: {
+		food_image_url: {
 			type: ["string", "null"],
 		},
-		FoodName: {
+		food_name: {
 			type: "string",
 		},
-		PriceAtOrder: {
+		price_at_order: {
 			format: "int64",
 			type: "integer",
 		},
 	},
-	required: ["FoodName", "FoodImageUrl", "PriceAtOrder", "Details"],
+	required: ["food_name", "food_image_url", "price_at_order", "details"],
 	type: "object",
 } as const;
 
 export const OrderItemDetailSchema = {
 	additionalProperties: false,
 	properties: {
-		Quantity: {
+		quantity: {
 			format: "int64",
 			type: "integer",
 		},
-		User: {
+		user: {
 			$ref: "#/components/schemas/UserProfile",
 		},
 	},
-	required: ["User", "Quantity"],
+	required: ["user", "quantity"],
 	type: "object",
 } as const;
 

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -151,10 +151,10 @@ export type GetFoodsQueryResponse = {
 };
 
 export type GetTodayOrdersResponse = {
-	Buyer: UserProfile;
-	OrderItems: Array<OrderItem> | null;
-	PollID: string;
-	TotalPrice: number;
+	buyer: UserProfile;
+	order_items: Array<OrderItem> | null;
+	poll_id: string;
+	total_price: number;
 };
 
 export type GetTodayPollsQueryResponse = {
@@ -187,15 +187,15 @@ export type IdentityData = {
 };
 
 export type OrderItem = {
-	Details: Array<OrderItemDetail> | null;
-	FoodImageUrl: string | null;
-	FoodName: string;
-	PriceAtOrder: number;
+	details: Array<OrderItemDetail> | null;
+	food_image_url: string | null;
+	food_name: string;
+	price_at_order: number;
 };
 
 export type OrderItemDetail = {
-	Quantity: number;
-	User: UserProfile;
+	quantity: number;
+	user: UserProfile;
 };
 
 export type PollOption = {

--- a/frontend/src/client/zod.gen.ts
+++ b/frontend/src/client/zod.gen.ts
@@ -120,22 +120,22 @@ export const zGetFoodsQueryResponse = z.object({
 });
 
 export const zOrderItemDetail = z.object({
-	Quantity: z.coerce.bigint(),
-	User: zUserProfile,
+	quantity: z.coerce.bigint(),
+	user: zUserProfile,
 });
 
 export const zOrderItem = z.object({
-	Details: z.union([z.array(zOrderItemDetail), z.null()]),
-	FoodImageUrl: z.union([z.string(), z.null()]),
-	FoodName: z.string(),
-	PriceAtOrder: z.coerce.bigint(),
+	details: z.union([z.array(zOrderItemDetail), z.null()]),
+	food_image_url: z.union([z.string(), z.null()]),
+	food_name: z.string(),
+	price_at_order: z.coerce.bigint(),
 });
 
 export const zGetTodayOrdersResponse = z.object({
-	Buyer: zUserProfile,
-	OrderItems: z.union([z.array(zOrderItem), z.null()]),
-	PollID: z.string(),
-	TotalPrice: z.coerce.bigint(),
+	buyer: zUserProfile,
+	order_items: z.union([z.array(zOrderItem), z.null()]),
+	poll_id: z.string(),
+	total_price: z.coerce.bigint(),
 });
 
 export const zVote = z.object({

--- a/frontend/src/features/polls/api/get-today-polls.ts
+++ b/frontend/src/features/polls/api/get-today-polls.ts
@@ -3,9 +3,10 @@ import { listPollsToday } from "@/client/sdk.gen";
 import { createServerFn } from "@tanstack/react-start";
 
 export const listPollsTodayServerFn = createServerFn({ method: "GET" }).handler(
-  async () => {
+  async ({ signal }) => {
     const { data, error } = await listPollsToday({
       client: serverClient,
+      signal,
     });
     console.log("Today Polls Data:", data, "Error:", error);
 

--- a/frontend/src/lib/fetch-user-server-fn.ts
+++ b/frontend/src/lib/fetch-user-server-fn.ts
@@ -1,7 +1,7 @@
 import { createClient } from "@/lib/server";
 import type { Factor, User } from "@supabase/supabase-js";
 import { createServerFn } from "@tanstack/react-start";
-type SSRSafeUser = User & {
+export type SSRSafeUser = User & {
   factors: (Factor & { factor_type: "phone" | "totp" })[];
   app_metadata: {
     provider: string | null;

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -5,6 +5,7 @@ import {
   HeadContent,
   Scripts,
   createRootRouteWithContext,
+  useRouterState,
 } from "@tanstack/react-router";
 import { TanStackRouterDevtoolsPanel } from "@tanstack/react-router-devtools";
 
@@ -19,40 +20,48 @@ import { ImageKitProvider } from "@imagekit/react";
 import type { QueryClient } from "@tanstack/react-query";
 import { MotionConfig } from "motion/react";
 
-interface MyRouterContext {
+export interface MyRouterContext {
   queryClient: QueryClient;
+  pageTitle: string;
 }
 
 export const Route = createRootRouteWithContext<MyRouterContext>()({
-  head: () => ({
-    meta: [
-      {
-        charSet: "utf-8",
-      },
-      {
-        name: "viewport",
-        content: "width=device-width, initial-scale=1",
-      },
-      {
-        title: "TanStack Start Starter",
-      },
-    ],
-    links: [
-      {
-        rel: "stylesheet",
-        href: appCss,
-      },
-    ],
-  }),
+  head: () => {
+    return {
+      meta: [
+        {
+          charSet: "utf-8",
+        },
+        {
+          name: "viewport",
+          content: "width=device-width, initial-scale=1",
+        },
+        {
+          title: "Weeate",
+        },
+      ],
+      links: [
+        {
+          rel: "stylesheet",
+          href: appCss,
+        },
+      ],
+    };
+  },
   shellComponent: RootDocument,
 });
 
 function RootDocument({ children }: { children: React.ReactNode }) {
+  const { matches } = useRouterState();
+  const currentRoute = matches[matches.length - 1];
+  const pageTitle = currentRoute?.context.pageTitle;
+
   const { isMobile } = useIsMobile();
   return (
     <html lang="en">
       <head>
         <HeadContent />
+        <title>{`${pageTitle} | Weeate`}</title>
       </head>
       <body>
         <ImageKitProvider

--- a/frontend/src/routes/_protected/foods/index.tsx
+++ b/frontend/src/routes/_protected/foods/index.tsx
@@ -1,25 +1,18 @@
 import { listFoodsOptions } from "@/client/@tanstack/react-query.gen";
 import { createFileRoute } from "@tanstack/react-router";
 
-import { useQuery } from "@tanstack/react-query";
-import { createColumns } from "@/features/foods/components/columns";
 import { DataTable } from "@/components/simple-data-table/data-table";
 import AddFoodDialog from "@/features/foods/components/add-food-dialog";
-import { useMemo } from "react";
+import { createColumns } from "@/features/foods/components/columns";
 import { getFoodsServer } from "@/features/foods/functions/get-server-foods";
-import { getPageTitle } from "@/lib/head-utils";
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
 
 export const Route = createFileRoute("/_protected/foods/")({
-  head: () => {
-    return {
-      meta: [
-        {
-          title: getPageTitle("Foods"),
-        },
-      ],
-    };
-  },
   component: Foods,
+  beforeLoad: ({ context }) => {
+    context.pageTitle = "Foods";
+  },
   loader: async () => ({
     initialData: await getFoodsServer({ data: { query: {} } }),
   }),

--- a/frontend/src/routes/_protected/index.tsx
+++ b/frontend/src/routes/_protected/index.tsx
@@ -1,9 +1,30 @@
+import { DataTable } from "@/components/data-table/data-table";
+import { Card } from "@/components/ui/card";
 import { createFileRoute } from "@tanstack/react-router";
+import { getCoreRowModel, useReactTable } from "@tanstack/react-table";
 
 export const Route = createFileRoute("/_protected/")({
-  component: App,
+  component: Index,
+  beforeLoad: () => {
+    return {
+      pageTitle: "Home",
+    };
+  },
 });
 
-function App() {
-  return <div>Test</div>;
+function Index() {
+  const table = useReactTable({
+    data: [],
+    columns: [],
+    getCoreRowModel: getCoreRowModel(),
+  });
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+      <Card></Card>
+
+      <Card></Card>
+
+      <DataTable className="md:col-span-2" table={table}></DataTable>
+    </div>
+  );
 }

--- a/frontend/src/routes/_protected/polls/today/index.tsx
+++ b/frontend/src/routes/_protected/polls/today/index.tsx
@@ -1,32 +1,27 @@
 import { GetTodayPollsQueryResponse, Vote } from "@/client";
-import {
-  listPollsTodayOptions,
-  listPollsTodayQueryKey,
-} from "@/client/@tanstack/react-query.gen";
+import { listPollsTodayQueryKey } from "@/client/@tanstack/react-query.gen";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { listPollsTodayServerFn } from "@/features/polls/api/get-today-polls";
 import CreatePollDialog from "@/features/polls/components/create-poll-dialog";
 import PollCard from "@/features/polls/components/poll-card";
 import { useSubscription } from "@/lib/centrifugo/use-subscription";
-import { getPageTitle } from "@/lib/head-utils";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
+import { useServerFn } from "@tanstack/react-start";
 import { toast } from "sonner";
 
 export const Route = createFileRoute("/_protected/polls/today/")({
   component: RouteComponent,
-  loader: async () => {
-    const polls = await listPollsTodayServerFn();
-    return { polls };
-  },
-  head: () => {
+  beforeLoad: () => {
     return {
-      meta: [
-        {
-          title: getPageTitle("Today Polls"),
-        },
-      ],
+      pageTitle: "Today's Polls",
     };
+  },
+  loader: async ({ abortController }) => {
+    const polls = await listPollsTodayServerFn({
+      signal: abortController.signal,
+    });
+    return { polls };
   },
 });
 
@@ -34,19 +29,22 @@ function RouteComponent() {
   const { polls } = Route.useLoaderData();
   const { user } = Route.useRouteContext();
 
-  const { data, refetch } = useQuery({
-    ...listPollsTodayOptions(),
-    queryFn: listPollsTodayServerFn,
+  const queryClient = useQueryClient();
+
+  // Wrap server function for client-side use
+  const fetchPolls = useServerFn(listPollsTodayServerFn);
+
+  const { data } = useQuery({
+    queryKey: listPollsTodayQueryKey(),
+    queryFn: () => fetchPolls(),
     initialData: polls,
   });
 
-  const queryClient = useQueryClient();
-
-  useSubscription("public:polls", async (data) => {
+  useSubscription("public:polls", (data) => {
     console.log("Vote moved event received", data);
     if (data.type === "poll_created") {
       toast("New poll created, refetching today's polls...");
-      await refetch();
+      queryClient.invalidateQueries({ queryKey: listPollsTodayQueryKey() });
     }
     if (data.type === "vote_added") {
       queryClient.setQueryData(
@@ -171,12 +169,7 @@ function RouteComponent() {
   return (
     <div className="flex flex-col gap-6">
       <div className="flex flex-col gap-3">
-        <div className="flex flex-col sm:flex-row justify-between items-center gap-3">
-          <div className="flex flex-col self-start">
-            <h1 className="text-2xl font-bold">Today Food Polls</h1>
-            <p>Vote for your favorite meals and let your voice be heard!</p>
-          </div>
-
+        <div className="flex w-full flex-col items-center justify-end gap-3 sm:flex-row">
           <CreatePollDialog
             userPollExists={data?.some((poll) => poll.creator?.id === user?.id)}
           />
@@ -185,10 +178,10 @@ function RouteComponent() {
         <div className="flex gap-2 text-center">
           <Card className="basis-1/2 md:basis-[200px] gap-2 py-4">
             <CardHeader>
-              <CardTitle>Today Polls</CardTitle>
+              <CardTitle>Polls</CardTitle>
             </CardHeader>
             <CardContent>
-              <span className="font-bold">{polls?.length || 0}</span>
+              <span className="font-bold">{data?.length || 0}</span>
             </CardContent>
           </Card>
           <Card className="basis-1/2 md:basis-[200px] gap-2 py-4">

--- a/frontend/src/routes/_protected/protected.tsx
+++ b/frontend/src/routes/_protected/protected.tsx
@@ -12,7 +12,6 @@ export const Route = createFileRoute("/_protected/protected")({
 });
 
 function Info() {
-  const { user } = Route.useLoaderData();
   return (
     <div>
       <MenuGrid />

--- a/frontend/src/routes/_protected/route.tsx
+++ b/frontend/src/routes/_protected/route.tsx
@@ -6,7 +6,13 @@ import {
 import AppSidebar from "@/components/app-sidebar";
 import { CentrifugoProvider } from "@/lib/centrifugo/centrifugo-context";
 import { fetchUser } from "@/lib/fetch-user-server-fn";
-import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
+import { ProtectedRouteContext } from "@/types/route-context";
+import {
+  createFileRoute,
+  Outlet,
+  redirect,
+  useMatches,
+} from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_protected")({
   beforeLoad: async () => {
@@ -25,6 +31,11 @@ export const Route = createFileRoute("/_protected")({
 });
 
 function ProtectedLayout() {
+  const matches = useMatches();
+  const { context } = matches[matches.length - 1] as {
+    context: ProtectedRouteContext;
+  };
+
   return (
     <CentrifugoProvider>
       <SidebarProvider>
@@ -32,6 +43,11 @@ function ProtectedLayout() {
         <SidebarInset>
           <SidebarTrigger className="size-12" />
           <div className="container mx-auto p-10 xxl:px-0">
+            {context.pageTitle && (
+              <div className="mb-6">
+                <h1 className="text-3xl font-bold">{context.pageTitle}</h1>
+              </div>
+            )}
             <Outlet />
           </div>
         </SidebarInset>

--- a/frontend/src/types/route-context.ts
+++ b/frontend/src/types/route-context.ts
@@ -1,0 +1,12 @@
+/**
+ * Extended context for protected routes
+ */
+export interface ProtectedRouteContext {
+  pageTitle?: string;
+  user: {
+    id: string;
+    display_name?: string;
+    avatar_url?: string;
+    created_at: string;
+  };
+}


### PR DESCRIPTION
Add a ProtectedRouteContext type and wire it into the protected layout so pages can set a pageTitle from beforeLoad. Use useMatches to read the route context in ProtectedLayout and render a page heading when context.pageTitle is present. Update the Foods route to set its pageTitle in beforeLoad (migrating from head meta logic) and re-order imports for clarity. Also add Prettier and prettier-plugin-tailwindcss  to bun.lock (lockfile) to keep formatting tooling pinned. This enables consistent server-side provision of route-scoped UI metadata (page titles) and simplifies head handling for protected routes. It also ensures formatting plugins are locked for reproducible dev environments.