### PR TITLE
✨ feat(api): make arrays and optional fields non-nullable in schemas

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Attach to Process",
+      "type": "go",
+      "request": "attach",
+      "mode": "local",
+      "processId": 0
+    }
+  ]
+}

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -20,8 +20,8 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humafiber"
 	"github.com/gofiber/fiber/v2"
-	"github.com/gofiber/fiber/v2/middleware/recover"
 	"github.com/gofiber/fiber/v2/middleware/healthcheck"
+	"github.com/gofiber/fiber/v2/middleware/recover"
 	slogfiber "github.com/samber/slog-fiber"
 	"gorm.io/gorm"
 )
@@ -73,6 +73,7 @@ func (s *Server) buildHandler(ctx context.Context) (http.Handler, []func(context
 	app.Use(authMiddleware)
 
 	api := humafiber.New(app, huma.DefaultConfig("Weeate API", "v1.0.0"))
+	huma.DefaultArrayNullable = false
 
 	authModule := auth.NewAuthModule(s.config)
 	authModule.RegisterAPI(api)

--- a/backend/internal/common/api/response.go
+++ b/backend/internal/common/api/response.go
@@ -5,5 +5,9 @@ type Response[T any] struct {
 }
 
 func NewResponse[T any](body *T) *Response[T] {
+	if body == nil {
+		var empty T
+		return &Response[T]{Body: empty}
+	}
 	return &Response[T]{Body: *body}
 }

--- a/backend/internal/features/foods/services/get_foods.go
+++ b/backend/internal/features/foods/services/get_foods.go
@@ -18,7 +18,7 @@ type GetFoodsQuery struct {
 type GetFoodsQueryResponse struct {
 	ID          uuid.UUID        `json:"id"`
 	Name        string           `json:"name"`
-	ImageURL    *string          `json:"image_url,omitempty"`
+	ImageURL    *string          `json:"image_url"`
 	Description string           `json:"description"`
 	Price       int64            `json:"price"`
 	User        auth.UserProfile `json:"user"`

--- a/backend/internal/features/orders/domain/errors.go
+++ b/backend/internal/features/orders/domain/errors.go
@@ -10,4 +10,5 @@ var (
 	ErrOrderAlreadyExists             = errors.New("order already exists")
 	ErrCannotCreateOrderWithZeroVotes = errors.New("cannot create order with zero votes")
 	ErrPollIDRequired                 = domain.NewError(domain.EInvalid, "poll ID is required")
+	ErrOrderResultsRequired           = domain.NewError(domain.EInvalid, "order results are required")
 )

--- a/backend/internal/features/orders/services/create_order.go
+++ b/backend/internal/features/orders/services/create_order.go
@@ -50,7 +50,19 @@ func (h *CreateOrderCommandHandler) Handle(ctx context.Context, req *CreateOrder
 		slog.WarnContext(ctx, "cannot create order without poll ID",
 			"buyerID", req.BuyerID,
 			"orderDate", req.OrderDate)
-		return domain.ErrPollIDRequired
+		return nil
+	}
+
+	totalVote := lo.SumBy(req.Results, func(r OptionResult) int {
+		return len(r.Votes)
+	})
+
+	if len(req.Results) == 0 || totalVote == 0 {
+		slog.InfoContext(ctx, "poll closed with no votes, skipping order creation",
+			"pollID", req.PollID,
+			"buyerID", req.BuyerID,
+			"orderDate", req.OrderDate)
+		return nil // Don't return error - this is a valid case
 	}
 
 	r, err := gorm.G[domain.Order](h.db).Where("order_date = ?", req.OrderDate).
@@ -104,6 +116,9 @@ func (h *CreateOrderCommandHandler) Handle(ctx context.Context, req *CreateOrder
 
 	orderItems := make([]domain.OrderItem, 0)
 	for _, option := range req.Results {
+		if len(option.Votes) == 0 {
+			continue
+		}
 		orderItemDetails := make([]domain.OrderItemDetail, 0)
 		for _, vote := range option.Votes {
 			orderItemDetails = append(orderItemDetails, *domain.NewOrderItemDetail(vote.UserID, vote.Quantity))

--- a/backend/internal/features/orders/services/get_ordered_items.go
+++ b/backend/internal/features/orders/services/get_ordered_items.go
@@ -15,7 +15,7 @@ type GetOrderedItemsQuery struct {
 }
 
 type GetOrderedItemsResponse struct {
-	Items []OrderedItem `json:"items"`
+	Items []OrderedItem `json:"items" nullable:"false"`
 }
 
 type OrderedItem struct {

--- a/backend/internal/features/orders/services/get_shopping_order.go
+++ b/backend/internal/features/orders/services/get_shopping_order.go
@@ -17,7 +17,7 @@ type GetShoppingOrderQuery struct {
 
 type GetShoppingOrderResponse struct {
 	// Define the response fields here
-	Items      []ShoppingItem `json:"items"`
+	Items      []ShoppingItem `json:"items" nullable:"false" minItems:"1"`
 	TotalPrice int64          `json:"total_price"`
 }
 
@@ -27,7 +27,7 @@ type ShoppingItem struct {
 	Quantity   int64              `json:"quantity"`
 	UnitPrice  int64              `json:"unit_price"`
 	TotalPrice int64              `json:"total_price"`
-	Users      []auth.UserProfile `json:"users"`
+	Users      []auth.UserProfile `json:"users" nullable:"false" minItems:"1"`
 }
 
 type GetShoppingOrderQueryHandler struct {

--- a/backend/internal/features/polls/domain/poll.go
+++ b/backend/internal/features/polls/domain/poll.go
@@ -11,13 +11,12 @@ import (
 
 type Poll struct {
 	domain.Base
-	BuyerID           string         `gorm:"not null;uniqueIndex:idx_poll_order_date_buyer"`
-	OrderDate         time.Time      `gorm:"type:date;not null;uniqueIndex:idx_poll_order_date_buyer"`
-	ScheduledClosesAt time.Time      `gorm:"not null"`
-	Strategy          PollStrategy   `gorm:"type:varchar(100);not null;check:strategy IN ('ORDER_MULTIPLE_ITEMS', 'ORDER_CONSENSUS_ITEM')"`
-	ClosedAt          *time.Time     `gorm:"nullable"`
-	PollOptions       []PollOption   `gorm:"foreignKey:PollID;constraint:OnDelete:CASCADE;"`
-	events            []domain.Event `gorm:"-"`
+	BuyerID           string       `gorm:"not null;uniqueIndex:idx_poll_order_date_buyer"`
+	OrderDate         time.Time    `gorm:"type:date;not null;uniqueIndex:idx_poll_order_date_buyer"`
+	ScheduledClosesAt time.Time    `gorm:"not null"`
+	Strategy          PollStrategy `gorm:"type:varchar(100);not null;check:strategy IN ('ORDER_PERSONAL_CHOICE', 'ORDER_CONSENSUS_ITEM')"`
+	ClosedAt          *time.Time   `gorm:"nullable"`
+	PollOptions       []PollOption `gorm:"foreignKey:PollID;constraint:OnDelete:CASCADE;"`
 }
 
 func NewPoll(orderDate, scheduledClosesAt time.Time, strategy PollStrategy, pollOptions []PollOption, buyerID string) (*Poll, error) {
@@ -43,10 +42,10 @@ func NewPoll(orderDate, scheduledClosesAt time.Time, strategy PollStrategy, poll
 	return poll, nil
 }
 
-func (p *Poll) Close() {
+func (p *Poll) Close() (*Poll, domain.Event) {
 	now := time.Now().UTC()
 	p.ClosedAt = &now
-	p.events = append(p.events, events.PollClosedEvent{
+	event := events.PollClosedEvent{
 		PollID:    p.ID,
 		BuyerID:   p.BuyerID,
 		OrderDate: p.OrderDate,
@@ -64,13 +63,9 @@ func (p *Poll) Close() {
 				}),
 			}
 		}),
-	})
-}
+	}
 
-func (p *Poll) PullEvents() []domain.Event {
-	events := p.events
-	p.events = nil
-	return events
+	return p, event
 }
 
 type CastVoteResult struct {

--- a/backend/internal/features/polls/domain/poll_strategy.go
+++ b/backend/internal/features/polls/domain/poll_strategy.go
@@ -8,7 +8,7 @@ import (
 type PollStrategy string
 
 const (
-	OrderMultiple  PollStrategy = "ORDER_MULTIPLE_ITEMS"
+	OrderMultiple  PollStrategy = "ORDER_PERSONAL_CHOICE"
 	OrderConsensus PollStrategy = "ORDER_CONSENSUS_ITEM"
 )
 

--- a/backend/internal/features/polls/infrastructure/jobs/close_polls_scheduler.go
+++ b/backend/internal/features/polls/infrastructure/jobs/close_polls_scheduler.go
@@ -84,8 +84,9 @@ func (s *ClosePollScheduler) TriggerUpdate() {
 }
 
 func (s *ClosePollScheduler) closeDuePolls(ctx context.Context) {
-	duePolls, err := gorm.G[domain.Poll](s.db).Where("closed_at IS NULL").
-		Where("scheduled_closes_at <= ? AND closed_at IS NULL", time.Now()).
+	duePolls, err := gorm.G[domain.Poll](s.db).
+		Where("closed_at IS NULL").
+		Where("scheduled_closes_at <= ?", time.Now()).
 		Find(ctx)
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to fetch due polls", "error", err)

--- a/backend/internal/features/polls/services/close_poll_command.go
+++ b/backend/internal/features/polls/services/close_poll_command.go
@@ -17,8 +17,8 @@ type ClosePollCommand struct {
 }
 
 type ClosePollCommandHandler struct {
-	db  *gorm.DB
-	bus *bus.Bus
+	db         *gorm.DB
+	bus        *bus.Bus
 	centrifugo *centrifugo.CentrifugoClient
 }
 
@@ -36,6 +36,7 @@ func (c *ClosePollCommandHandler) Handle(ctx context.Context, req ClosePollComma
 	}
 
 	poll, err := gorm.G[domain.Poll](c.db).
+		Preload("PollOptions.Votes", nil).
 		Where("id = ?", req.PollID).
 		First(ctx)
 	if err != nil {
@@ -46,7 +47,7 @@ func (c *ClosePollCommandHandler) Handle(ctx context.Context, req ClosePollComma
 		return domain.ErrPollAlreadyClosed
 	}
 
-	poll.Close()
+	closedPoll, event := poll.Close()
 
 	return c.db.Transaction(func(tx *gorm.DB) error {
 		db, ok := tx.Statement.ConnPool.(*sql.Tx)
@@ -54,21 +55,17 @@ func (c *ClosePollCommandHandler) Handle(ctx context.Context, req ClosePollComma
 			return errors.New("failed to get sql transaction")
 		}
 
-		if _, err := gorm.G[domain.Poll](tx).Updates(ctx, poll); err != nil {
+		if _, err := gorm.G[domain.Poll](tx).Updates(ctx, *closedPoll); err != nil {
 			return err
 		}
-
-		events := poll.PullEvents()
 
 		publisher, err := c.bus.NewSqlPublisher(db)
 		if err != nil {
 			return err
 		}
 
-		for _, event := range events {
-			if err := publisher.Publish(ctx, event); err != nil {
-				return err
-			}
+		if err := publisher.Publish(ctx, event); err != nil {
+			return err
 		}
 
 		return nil

--- a/backend/internal/features/polls/services/get_today_polls_query.go
+++ b/backend/internal/features/polls/services/get_today_polls_query.go
@@ -19,10 +19,10 @@ type (
 		ID                string              `json:"id"`
 		Creator           auth.UserProfile    `json:"creator"`
 		ScheduledClosesAt time.Time           `json:"scheduled_closes_at"`
-		FinalTotalPrice   int64               `json:"final_total_price"`
-		Strategy          domain.PollStrategy `json:"strategy"`
+		Strategy          domain.PollStrategy `json:"strategy" enum:"ORDER_CONSENSUS_ITEM,ORDER_PERSONAL_CHOICE"`
 		ClosedAt          *time.Time          `json:"closed_at"`
 		PollOptions       []PollOption        `json:"poll_options"`
+		OrderDate         time.Time           `json:"order_date" format:"date-time"`
 	}
 
 	PollOption struct {
@@ -33,8 +33,9 @@ type (
 	}
 
 	Food struct {
-		ID   string `json:"id"`
-		Name string `json:"name"`
+		ID       string  `json:"id"`
+		Name     string  `json:"name"`
+		ImageURL *string `json:"image_url"`
 	}
 
 	Vote struct {
@@ -115,6 +116,8 @@ func (h *GetTodayPollsQueryHandler) Handle(ctx context.Context, query GetTodayPo
 			Creator:           userProfileMap[poll.BuyerID],
 			ScheduledClosesAt: poll.ScheduledClosesAt,
 			Strategy:          poll.Strategy,
+			ClosedAt:          poll.ClosedAt,
+			OrderDate:         poll.OrderDate,
 			PollOptions: lo.Map(poll.PollOptions, func(option domain.PollOption, _ int) PollOption {
 				food := foodMap[option.FoodID.String()]
 				return PollOption{

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -17,7 +17,7 @@ services:
       - 3000:3000
     volumes:
       - ./frontend/:/app/frontend/
-      - ./.env:/app/.env
+      - /app/frontend/node_modules
     restart: on-failure
 
   backend:

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,8 +1,4 @@
-FROM oven/bun:1 AS builder
-
-WORKDIR /app
-
-COPY .env .
+FROM oven/bun:1-debian AS builder
 
 WORKDIR /app/frontend
 

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "frontend",

--- a/frontend/openapi-ts.config.ts
+++ b/frontend/openapi-ts.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "@hey-api/openapi-ts";
 export default defineConfig({
   input: {
     path: "http://localhost:8080/openapi.yaml",
-    watch: false,
+    watch: true,
   },
   interactive: true,
   output: {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "dotenvx run -f ../.env -- vite dev --port 3000 --host",
+    "dev": "vite dev --port 3000 --host",
     "build": "vite build",
     "serve": "vite preview",
     "test": "vitest run",

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -67,7 +67,7 @@ export const AppMetadataSchema = {
 			items: {
 				type: "string",
 			},
-			type: ["array", "null"],
+			type: "array",
 		},
 	},
 	required: ["avatar_url", "display_name", "provider", "providers"],
@@ -90,7 +90,7 @@ export const CreatePollCommandSchema = {
 				type: "string",
 			},
 			minItems: 1,
-			type: ["array", "null"],
+			type: "array",
 		},
 		order_date: {
 			description: "Date for which the poll is being created in RFC3339 format",
@@ -171,7 +171,7 @@ export const ErrorModelSchema = {
 			items: {
 				$ref: "#/components/schemas/ErrorDetail",
 			},
-			type: ["array", "null"],
+			type: "array",
 		},
 		instance: {
 			description:
@@ -210,11 +210,14 @@ export const FoodSchema = {
 		id: {
 			type: "string",
 		},
+		image_url: {
+			type: ["string", "null"],
+		},
 		name: {
 			type: "string",
 		},
 	},
-	required: ["id", "name"],
+	required: ["id", "name", "image_url"],
 	type: "object",
 } as const;
 
@@ -247,7 +250,7 @@ export const GetFoodsQueryResponseSchema = {
 			type: "string",
 		},
 		image_url: {
-			type: "string",
+			type: ["string", "null"],
 		},
 		name: {
 			type: "string",
@@ -260,7 +263,7 @@ export const GetFoodsQueryResponseSchema = {
 			$ref: "#/components/schemas/UserProfile",
 		},
 	},
-	required: ["id", "name", "description", "price", "user"],
+	required: ["id", "name", "image_url", "description", "price", "user"],
 	type: "object",
 } as const;
 
@@ -278,7 +281,7 @@ export const GetOrderedItemsResponseSchema = {
 			items: {
 				$ref: "#/components/schemas/OrderedItem",
 			},
-			type: ["array", "null"],
+			type: "array",
 		},
 	},
 	required: ["items"],
@@ -299,7 +302,8 @@ export const GetShoppingOrderResponseSchema = {
 			items: {
 				$ref: "#/components/schemas/ShoppingItem",
 			},
-			type: ["array", "null"],
+			minItems: 1,
+			type: "array",
 		},
 		total_price: {
 			format: "int64",
@@ -320,7 +324,7 @@ export const GetTodayOrdersResponseSchema = {
 			items: {
 				$ref: "#/components/schemas/OrderItem",
 			},
-			type: ["array", "null"],
+			type: "array",
 		},
 		poll_id: {
 			type: "string",
@@ -344,24 +348,25 @@ export const GetTodayPollsQueryResponseSchema = {
 		creator: {
 			$ref: "#/components/schemas/UserProfile",
 		},
-		final_total_price: {
-			format: "int64",
-			type: "integer",
-		},
 		id: {
+			type: "string",
+		},
+		order_date: {
+			format: "date-time",
 			type: "string",
 		},
 		poll_options: {
 			items: {
 				$ref: "#/components/schemas/PollOption",
 			},
-			type: ["array", "null"],
+			type: "array",
 		},
 		scheduled_closes_at: {
 			format: "date-time",
 			type: "string",
 		},
 		strategy: {
+			enum: ["ORDER_CONSENSUS_ITEM", "ORDER_PERSONAL_CHOICE"],
 			type: "string",
 		},
 	},
@@ -369,10 +374,10 @@ export const GetTodayPollsQueryResponseSchema = {
 		"id",
 		"creator",
 		"scheduled_closes_at",
-		"final_total_price",
 		"strategy",
 		"closed_at",
 		"poll_options",
+		"order_date",
 	],
 	type: "object",
 } as const;
@@ -449,7 +454,7 @@ export const OrderItemSchema = {
 			items: {
 				$ref: "#/components/schemas/OrderItemDetail",
 			},
-			type: ["array", "null"],
+			type: "array",
 		},
 		food_image_url: {
 			type: ["string", "null"],
@@ -538,7 +543,7 @@ export const PollOptionSchema = {
 			items: {
 				$ref: "#/components/schemas/Vote",
 			},
-			type: ["array", "null"],
+			type: "array",
 		},
 	},
 	required: ["id", "food", "price_at_creation", "votes"],
@@ -622,7 +627,8 @@ export const ShoppingItemSchema = {
 			items: {
 				$ref: "#/components/schemas/UserProfile",
 			},
-			type: ["array", "null"],
+			minItems: 1,
+			type: "array",
 		},
 	},
 	required: [
@@ -725,7 +731,7 @@ export const CreatePollCommandWritableSchema = {
 				type: "string",
 			},
 			minItems: 1,
-			type: ["array", "null"],
+			type: "array",
 		},
 		order_date: {
 			description: "Date for which the poll is being created in RFC3339 format",
@@ -773,7 +779,7 @@ export const ErrorModelWritableSchema = {
 			items: {
 				$ref: "#/components/schemas/ErrorDetail",
 			},
-			type: ["array", "null"],
+			type: "array",
 		},
 		instance: {
 			description:
@@ -825,7 +831,7 @@ export const GetOrderedItemsResponseWritableSchema = {
 			items: {
 				$ref: "#/components/schemas/OrderedItem",
 			},
-			type: ["array", "null"],
+			type: "array",
 		},
 	},
 	required: ["items"],
@@ -839,7 +845,8 @@ export const GetShoppingOrderResponseWritableSchema = {
 			items: {
 				$ref: "#/components/schemas/ShoppingItem",
 			},
-			type: ["array", "null"],
+			minItems: 1,
+			type: "array",
 		},
 		total_price: {
 			format: "int64",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -42,7 +42,7 @@ export type AppMetadata = {
 	avatar_url: string;
 	display_name: string;
 	provider: string;
-	providers: Array<string> | null;
+	providers: Array<string>;
 };
 
 export type CreatePollCommand = {
@@ -53,7 +53,7 @@ export type CreatePollCommand = {
 	/**
 	 * List of food IDs to include in the poll
 	 */
-	food_ids: Array<string> | null;
+	food_ids: Array<string>;
 	/**
 	 * Date for which the poll is being created in RFC3339 format
 	 */
@@ -106,7 +106,7 @@ export type ErrorModel = {
 	/**
 	 * Optional list of individual error details
 	 */
-	errors?: Array<ErrorDetail> | null;
+	errors?: Array<ErrorDetail>;
 	/**
 	 * A URI reference that identifies the specific occurrence of the problem.
 	 */
@@ -127,6 +127,7 @@ export type ErrorModel = {
 
 export type Food = {
 	id: string;
+	image_url: string | null;
 	name: string;
 };
 
@@ -144,7 +145,7 @@ export type GetCentrifugoJwtResponse = {
 export type GetFoodsQueryResponse = {
 	description: string;
 	id: string;
-	image_url?: string;
+	image_url: string | null;
 	name: string;
 	price: number;
 	user: UserProfile;
@@ -155,7 +156,7 @@ export type GetOrderedItemsResponse = {
 	 * A URL to the JSON Schema for this object.
 	 */
 	readonly $schema?: string;
-	items: Array<OrderedItem> | null;
+	items: Array<OrderedItem>;
 };
 
 export type GetShoppingOrderResponse = {
@@ -163,13 +164,13 @@ export type GetShoppingOrderResponse = {
 	 * A URL to the JSON Schema for this object.
 	 */
 	readonly $schema?: string;
-	items: Array<ShoppingItem> | null;
+	items: Array<ShoppingItem>;
 	total_price: number;
 };
 
 export type GetTodayOrdersResponse = {
 	buyer: UserProfile;
-	order_items: Array<OrderItem> | null;
+	order_items: Array<OrderItem>;
 	poll_id: string;
 	total_price: number;
 };
@@ -177,11 +178,11 @@ export type GetTodayOrdersResponse = {
 export type GetTodayPollsQueryResponse = {
 	closed_at: string | null;
 	creator: UserProfile;
-	final_total_price: number;
 	id: string;
-	poll_options: Array<PollOption> | null;
+	order_date: string;
+	poll_options: Array<PollOption>;
 	scheduled_closes_at: string;
-	strategy: string;
+	strategy: "ORDER_CONSENSUS_ITEM" | "ORDER_PERSONAL_CHOICE";
 };
 
 export type Identity = {
@@ -204,7 +205,7 @@ export type IdentityData = {
 };
 
 export type OrderItem = {
-	details: Array<OrderItemDetail> | null;
+	details: Array<OrderItemDetail>;
 	food_image_url: string | null;
 	food_name: string;
 	price_at_order: number;
@@ -229,7 +230,7 @@ export type PollOption = {
 	food: Food;
 	id: string;
 	price_at_creation: number;
-	votes: Array<Vote> | null;
+	votes: Array<Vote>;
 };
 
 export type PostByIdVoteRequest = {
@@ -272,7 +273,7 @@ export type ShoppingItem = {
 	quantity: number;
 	total_price: number;
 	unit_price: number;
-	users: Array<UserProfile> | null;
+	users: Array<UserProfile>;
 };
 
 export type UserMetadata = {
@@ -320,7 +321,7 @@ export type CreatePollCommandWritable = {
 	/**
 	 * List of food IDs to include in the poll
 	 */
-	food_ids: Array<string> | null;
+	food_ids: Array<string>;
 	/**
 	 * Date for which the poll is being created in RFC3339 format
 	 */
@@ -350,7 +351,7 @@ export type ErrorModelWritable = {
 	/**
 	 * Optional list of individual error details
 	 */
-	errors?: Array<ErrorDetail> | null;
+	errors?: Array<ErrorDetail>;
 	/**
 	 * A URI reference that identifies the specific occurrence of the problem.
 	 */
@@ -377,11 +378,11 @@ export type GetCentrifugoJwtResponseWritable = {
 };
 
 export type GetOrderedItemsResponseWritable = {
-	items: Array<OrderedItem> | null;
+	items: Array<OrderedItem>;
 };
 
 export type GetShoppingOrderResponseWritable = {
-	items: Array<ShoppingItem> | null;
+	items: Array<ShoppingItem>;
 	total_price: number;
 };
 
@@ -488,7 +489,7 @@ export type ListFoodsResponses = {
 	/**
 	 * OK
 	 */
-	200: Array<GetFoodsQueryResponse> | null;
+	200: Array<GetFoodsQueryResponse>;
 };
 
 export type ListFoodsResponse = ListFoodsResponses[keyof ListFoodsResponses];
@@ -634,7 +635,7 @@ export type ListOrdersTodayResponses = {
 	/**
 	 * OK
 	 */
-	200: Array<GetTodayOrdersResponse> | null;
+	200: Array<GetTodayOrdersResponse>;
 };
 
 export type ListOrdersTodayResponse =
@@ -686,7 +687,7 @@ export type ListPollsTodayResponses = {
 	/**
 	 * OK
 	 */
-	200: Array<GetTodayPollsQueryResponse> | null;
+	200: Array<GetTodayPollsQueryResponse>;
 };
 
 export type ListPollsTodayResponse =

--- a/frontend/src/client/zod.gen.ts
+++ b/frontend/src/client/zod.gen.ts
@@ -19,12 +19,12 @@ export const zAppMetadata = z.object({
 	avatar_url: z.string(),
 	display_name: z.string(),
 	provider: z.string(),
-	providers: z.union([z.array(z.string()), z.null()]),
+	providers: z.array(z.string()),
 });
 
 export const zCreatePollCommand = z.object({
 	$schema: z.optional(z.url().readonly()),
-	food_ids: z.union([z.array(z.string()).min(1), z.null()]),
+	food_ids: z.array(z.string()).min(1),
 	order_date: z.iso.datetime({ offset: true }),
 	scheduled_close_at: z.iso.datetime({ offset: true }),
 	strategy: z.enum(["ORDER_MULTIPLE_ITEMS", "ORDER_CONSENSUS_ITEM"]),
@@ -44,7 +44,7 @@ export const zErrorDetail = z.object({
 export const zErrorModel = z.object({
 	$schema: z.optional(z.url().readonly()),
 	detail: z.optional(z.string()),
-	errors: z.optional(z.union([z.array(zErrorDetail), z.null()])),
+	errors: z.optional(z.array(zErrorDetail)),
 	instance: z.optional(z.url()),
 	status: z.optional(z.coerce.bigint()),
 	title: z.optional(z.string()),
@@ -53,6 +53,7 @@ export const zErrorModel = z.object({
 
 export const zFood = z.object({
 	id: z.string(),
+	image_url: z.union([z.string(), z.null()]),
 	name: z.string(),
 });
 
@@ -107,7 +108,7 @@ export const zUserProfile = z.object({
 export const zGetFoodsQueryResponse = z.object({
 	description: z.string(),
 	id: z.string(),
-	image_url: z.optional(z.string()),
+	image_url: z.union([z.string(), z.null()]),
 	name: z.string(),
 	price: z.coerce.bigint(),
 	user: zUserProfile,
@@ -119,7 +120,7 @@ export const zOrderItemDetail = z.object({
 });
 
 export const zOrderItem = z.object({
-	details: z.union([z.array(zOrderItemDetail), z.null()]),
+	details: z.array(zOrderItemDetail),
 	food_image_url: z.union([z.string(), z.null()]),
 	food_name: z.string(),
 	price_at_order: z.coerce.bigint(),
@@ -127,7 +128,7 @@ export const zOrderItem = z.object({
 
 export const zGetTodayOrdersResponse = z.object({
 	buyer: zUserProfile,
-	order_items: z.union([z.array(zOrderItem), z.null()]),
+	order_items: z.array(zOrderItem),
 	poll_id: z.string(),
 	total_price: z.coerce.bigint(),
 });
@@ -144,7 +145,7 @@ export const zOrderedItem = z.object({
 
 export const zGetOrderedItemsResponse = z.object({
 	$schema: z.optional(z.url().readonly()),
-	items: z.union([z.array(zOrderedItem), z.null()]),
+	items: z.array(zOrderedItem),
 });
 
 export const zShoppingItem = z.object({
@@ -153,12 +154,12 @@ export const zShoppingItem = z.object({
 	quantity: z.coerce.bigint(),
 	total_price: z.coerce.bigint(),
 	unit_price: z.coerce.bigint(),
-	users: z.union([z.array(zUserProfile), z.null()]),
+	users: z.array(zUserProfile).min(1),
 });
 
 export const zGetShoppingOrderResponse = z.object({
 	$schema: z.optional(z.url().readonly()),
-	items: z.union([z.array(zShoppingItem), z.null()]),
+	items: z.array(zShoppingItem).min(1),
 	total_price: z.coerce.bigint(),
 });
 
@@ -170,17 +171,17 @@ export const zPollOption = z.object({
 	food: zFood,
 	id: z.string(),
 	price_at_creation: z.coerce.bigint(),
-	votes: z.union([z.array(zVote), z.null()]),
+	votes: z.array(zVote),
 });
 
 export const zGetTodayPollsQueryResponse = z.object({
 	closed_at: z.union([z.iso.datetime({ offset: true }), z.null()]),
 	creator: zUserProfile,
-	final_total_price: z.coerce.bigint(),
 	id: z.string(),
-	poll_options: z.union([z.array(zPollOption), z.null()]),
+	order_date: z.iso.datetime({ offset: true }),
+	poll_options: z.array(zPollOption),
 	scheduled_closes_at: z.iso.datetime({ offset: true }),
-	strategy: z.string(),
+	strategy: z.enum(["ORDER_CONSENSUS_ITEM", "ORDER_PERSONAL_CHOICE"]),
 });
 
 export const zAddFoodCommandWritable = z.object({
@@ -195,7 +196,7 @@ export const zAddFoodResultWritable = z.object({
 });
 
 export const zCreatePollCommandWritable = z.object({
-	food_ids: z.union([z.array(z.string()).min(1), z.null()]),
+	food_ids: z.array(z.string()).min(1),
 	order_date: z.iso.datetime({ offset: true }),
 	scheduled_close_at: z.iso.datetime({ offset: true }),
 	strategy: z.enum(["ORDER_MULTIPLE_ITEMS", "ORDER_CONSENSUS_ITEM"]),
@@ -207,7 +208,7 @@ export const zCreatePollResponseWritable = z.object({
 
 export const zErrorModelWritable = z.object({
 	detail: z.optional(z.string()),
-	errors: z.optional(z.union([z.array(zErrorDetail), z.null()])),
+	errors: z.optional(z.array(zErrorDetail)),
 	instance: z.optional(z.url()),
 	status: z.optional(z.coerce.bigint()),
 	title: z.optional(z.string()),
@@ -219,11 +220,11 @@ export const zGetCentrifugoJwtResponseWritable = z.object({
 });
 
 export const zGetOrderedItemsResponseWritable = z.object({
-	items: z.union([z.array(zOrderedItem), z.null()]),
+	items: z.array(zOrderedItem),
 });
 
 export const zGetShoppingOrderResponseWritable = z.object({
-	items: z.union([z.array(zShoppingItem), z.null()]),
+	items: z.array(zShoppingItem).min(1),
 	total_price: z.coerce.bigint(),
 });
 
@@ -273,10 +274,7 @@ export const zListFoodsData = z.object({
 /**
  * OK
  */
-export const zListFoodsResponse = z.union([
-	z.array(zGetFoodsQueryResponse),
-	z.null(),
-]);
+export const zListFoodsResponse = z.array(zGetFoodsQueryResponse);
 
 export const zPostFoodsData = z.object({
 	body: zAddFoodCommandWritable,
@@ -339,10 +337,7 @@ export const zListOrdersTodayData = z.object({
 /**
  * OK
  */
-export const zListOrdersTodayResponse = z.union([
-	z.array(zGetTodayOrdersResponse),
-	z.null(),
-]);
+export const zListOrdersTodayResponse = z.array(zGetTodayOrdersResponse);
 
 export const zPostPollsData = z.object({
 	body: zCreatePollCommandWritable,
@@ -364,10 +359,7 @@ export const zListPollsTodayData = z.object({
 /**
  * OK
  */
-export const zListPollsTodayResponse = z.union([
-	z.array(zGetTodayPollsQueryResponse),
-	z.null(),
-]);
+export const zListPollsTodayResponse = z.array(zGetTodayPollsQueryResponse);
 
 export const zPostPollsByIdCloseData = z.object({
 	body: z.optional(z.never()),

--- a/frontend/src/components/close-timer.tsx
+++ b/frontend/src/components/close-timer.tsx
@@ -1,4 +1,4 @@
-import { differenceInSeconds, format } from "date-fns";
+import { differenceInSeconds, format, isToday, isTomorrow } from "date-fns";
 import { AlertCircle, CheckCircle2, Clock, Hourglass } from "lucide-react";
 import { useEffect, useState } from "react";
 
@@ -37,6 +37,16 @@ const CloseTimer = ({ closesAt, className }: CloseTimerProps) => {
   const closeDate = new Date(closesAt);
   const totalSecondsLeft = differenceInSeconds(closeDate, now);
   const absoluteTime = format(closeDate, "h:mm a");
+
+  // Determine if close date is today or tomorrow
+  const isTodayDate = isToday(closeDate);
+  const isTomorrowDate = isTomorrow(closeDate);
+
+  const getTimeLabel = () => {
+    if (isTodayDate) return `Closes at ${absoluteTime}`;
+    if (isTomorrowDate) return `Closes tomorrow at ${absoluteTime}`;
+    return `Closes at ${absoluteTime}`;
+  };
 
   // --- STATE 1: CLOSED ---
   if (totalSecondsLeft <= 0) {
@@ -94,7 +104,7 @@ const CloseTimer = ({ closesAt, className }: CloseTimerProps) => {
             </Badge>
           </TooltipTrigger>
           <TooltipContent>
-            <p>Closes at {absoluteTime}</p>
+            <p>{getTimeLabel()}</p>
           </TooltipContent>
         </Tooltip>
       </TooltipProvider>
@@ -111,7 +121,7 @@ const CloseTimer = ({ closesAt, className }: CloseTimerProps) => {
             className={cn("gap-1.5 pl-1.5", className)} // Merge here
           >
             <Clock className="h-3.5 w-3.5" />
-            <span>Closes at {absoluteTime}</span>
+            <span>{getTimeLabel()}</span>
           </Badge>
         </TooltipTrigger>
         <TooltipContent>
@@ -121,5 +131,4 @@ const CloseTimer = ({ closesAt, className }: CloseTimerProps) => {
     </TooltipProvider>
   );
 };
-
 export default CloseTimer;

--- a/frontend/src/features/orders/components/meal-card.tsx
+++ b/frontend/src/features/orders/components/meal-card.tsx
@@ -8,76 +8,59 @@ import {
 } from "@/components/ui/card";
 import { FoodImage } from "@/features/foods/components/food-image";
 
-import { Button } from "@/components/animate-ui/components/buttons/button";
-import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTrigger,
-} from "@/components/animate-ui/components/radix/dialog";
-import { ImageWithFallback } from "@/components/image-with-fallback";
+import { OrderedItem } from "@/client";
 
-const QRPayDialog = () => {
-  return (
-    <Dialog>
-      <DialogTrigger asChild>
-        <Button>Pay now</Button>
-      </DialogTrigger>
-      <DialogContent>
-        <DialogHeader>
-          <h3 className="text-lg font-semibold">Scan to Pay</h3>
-        </DialogHeader>
-        <div>
-          <ImageWithFallback src={""} alt={"QR Code"}></ImageWithFallback>
-        </div>
-        <DialogFooter>
-          <DialogClose>
-            <Button variant="outline">Close</Button>
-          </DialogClose>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  );
+type Props = {
+  orderedItems: OrderedItem[];
 };
 
-type Props = {};
-
-const MealCard = ({}: Props) => {
+const MealCard = ({ orderedItems }: Props) => {
   return (
     <div className="flex flex-col gap-3">
       <h3 className="text-2xl font-bold">Your Meal</h3>
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex justify-between text-xl">
-            <span>Food Name</span>
-            <span>
-              {Intl.NumberFormat("vi-VN", {
-                style: "currency",
-                currency: "VND",
-              }).format(100000)}
-            </span>
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="p-0 aspect-square sm:aspect-video ">
-          <FoodImage className="h-auto max-w-full" src={""} alt={""} />
-        </CardContent>
+      {orderedItems.map((item) => {
+        return (
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex justify-between text-xl">
+                <span>{item.food_name}</span>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="p-0 aspect-square sm:aspect-video ">
+              <FoodImage
+                className="h-auto max-w-full"
+                src={item.food_url}
+                alt={item.food_name}
+              />
+            </CardContent>
 
-        <CardFooter className="flex justify-between">
-          <div className="flex items-center gap-2">
-            <Avatar className="size-8 sm:size-10">
-              <AvatarImage src={""} />
-              <AvatarFallback>BY</AvatarFallback>
-            </Avatar>
-            <h3 className="text-base sm:text-lg leading-tight text-primary">
-              Buyer
-            </h3>
-          </div>
+            <CardFooter className="flex justify-between items-center">
+              <div className="flex items-center gap-2 w-full">
+                <Avatar className="size-8 sm:size-10">
+                  <AvatarImage src={item.buyer.avatar_url} />
+                  <AvatarFallback>
+                    {item.buyer.display_name?.slice(0, 2) ?? "BU"}
+                  </AvatarFallback>
+                </Avatar>
+                <h3 className="text-base sm:text-lg leading-tight text-primary">
+                  {item.buyer.display_name}
+                </h3>
+              </div>
 
-          <QRPayDialog />
-        </CardFooter>
-      </Card>
+              <div className="flex flex-col sm:flex-row items-center justify-end w-full text-lg">
+                <span className="font-bold mr-2">Total Cost:</span>
+                <span className="font-medium text-slate-700">
+                  {Intl.NumberFormat("vi-VN", {
+                    style: "currency",
+                    currency: "VND",
+                  }).format(item.total_price)}
+                </span>
+              </div>
+              {/* <QRPayDialog /> */}
+            </CardFooter>
+          </Card>
+        );
+      })}
     </div>
   );
 };

--- a/frontend/src/features/orders/components/qr-pay-dialog.tsx
+++ b/frontend/src/features/orders/components/qr-pay-dialog.tsx
@@ -1,0 +1,35 @@
+import { Button } from "@/components/animate-ui/components/buttons/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTrigger,
+} from "@/components/animate-ui/components/radix/dialog";
+import { ImageWithFallback } from "@/components/image-with-fallback";
+
+const QRPayDialog = () => {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button>Pay now</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <h3 className="text-lg font-semibold">Scan to Pay</h3>
+        </DialogHeader>
+        <div>
+          <ImageWithFallback src={""} alt={"QR Code"}></ImageWithFallback>
+        </div>
+        <DialogFooter>
+          <DialogClose>
+            <Button variant="outline">Close</Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default QRPayDialog;

--- a/frontend/src/features/orders/components/shopping-card.tsx
+++ b/frontend/src/features/orders/components/shopping-card.tsx
@@ -1,9 +1,16 @@
+import { GetShoppingOrderResponseWritable } from "@/client";
 import {
   AvatarGroup,
   AvatarGroupTooltip,
 } from "@/components/animate-ui/components/animate/avatar-group";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import {
   Item,
   ItemContent,
@@ -13,63 +20,57 @@ import {
 } from "@/components/ui/item";
 import { AvatarImage } from "@radix-ui/react-avatar";
 
-type Props = {};
+type Props = {
+  shoppingOrder: GetShoppingOrderResponseWritable;
+};
 
-const ShoppingCard = ({}: Props) => {
+const ShoppingCard = ({ shoppingOrder }: Props) => {
   return (
     <div className="flex flex-col gap-3">
       <h3 className="text-2xl font-bold">Shopping List</h3>
       <Card>
         <CardHeader>
           <CardTitle className="flex justify-between text-xl">
-            <span>Total items: 3</span>
-            <span>
-              {Intl.NumberFormat("vi-VN", {
-                style: "currency",
-                currency: "VND",
-              }).format(100000)}
-            </span>
+            <span>Total items: {shoppingOrder.items?.length ?? 0}</span>
           </CardTitle>
         </CardHeader>
         <CardContent className="flex flex-col gap-3 p-4">
-          {[1, 2].map((item) => (
-            <Item key={item} variant={"outline"}>
+          {shoppingOrder.items.map((item) => (
+            <Item key={item.food_id} variant={"outline"}>
               <ItemMedia>
                 <AvatarGroup>
-                  <Avatar key={0}>
-                    <AvatarImage src={""} />
-                    <AvatarFallback>BY</AvatarFallback>
-                    <AvatarGroupTooltip>Buyer</AvatarGroupTooltip>
-                  </Avatar>
-
-                  <Avatar key={1}>
-                    <AvatarImage src={""} />
-                    <AvatarFallback>BY</AvatarFallback>
-                    <AvatarGroupTooltip>Buyer2</AvatarGroupTooltip>
-                  </Avatar>
+                  {item.users.map((user) => (
+                    <Avatar key={user.id}>
+                      <AvatarImage src={user.avatar_url} />
+                      <AvatarFallback>
+                        {user.display_name.slice(0, 2)}
+                      </AvatarFallback>
+                      <AvatarGroupTooltip>
+                        {user.display_name}
+                      </AvatarGroupTooltip>
+                    </Avatar>
+                  ))}
                 </AvatarGroup>
               </ItemMedia>
               <ItemContent>
-                <ItemTitle>Test</ItemTitle>
-                <ItemDescription>Quantity: 1</ItemDescription>
+                <ItemTitle>{item.food_name}</ItemTitle>
+                <ItemDescription>Quantity: {item.quantity}</ItemDescription>
               </ItemContent>
             </Item>
           ))}
         </CardContent>
 
-        {/* <CardFooter className="flex justify-between">
-          <div className="flex items-center gap-2">
-            <Avatar className="size-8 sm:size-10">
-              <AvatarImage src={""} />
-              <AvatarFallback>BY</AvatarFallback>
-            </Avatar>
-            <h3 className="text-base sm:text-lg leading-tight text-primary">
-              Buyer
-            </h3>
+        <CardFooter className="flex justify-end items-center">
+          <div className="flex flex-col sm:flex-row items-center justify-end w-full text-lg">
+            <span className="font-bold mr-2">Total Cost:</span>
+            <span className="font-medium text-slate-700">
+              {Intl.NumberFormat("vi-VN", {
+                style: "currency",
+                currency: "VND",
+              }).format(shoppingOrder.total_price)}
+            </span>
           </div>
-
-          <QRPayDialog />
-        </CardFooter> */}
+        </CardFooter>
       </Card>
     </div>
   );

--- a/frontend/src/features/polls/api/get-today-polls.ts
+++ b/frontend/src/features/polls/api/get-today-polls.ts
@@ -11,9 +11,11 @@ export const listPollsTodayServerFn = createServerFn({ method: "GET" }).handler(
     console.log("Today Polls Data:", data, "Error:", error);
 
     if (error) {
-      throw error;
+      return {
+        error: error.errors?.at(0)?.message ?? "Failed to fetch today's polls",
+      };
     }
 
-    return data;
+    return { data };
   }
 );

--- a/frontend/src/features/polls/components/create-poll-dialog.tsx
+++ b/frontend/src/features/polls/components/create-poll-dialog.tsx
@@ -2,6 +2,7 @@ import { serverClient } from "@/api";
 import {
   CreatePollCommand,
   CreatePollCommandWritable,
+  GetTodayPollsQueryResponse,
   postPolls,
 } from "@/client";
 import {
@@ -95,17 +96,21 @@ const createPollServerFn = createServerFn({ method: "POST" })
   });
 
 type Props = {
-  userPollExists?: boolean;
+  userPoll?: GetTodayPollsQueryResponse;
 };
 
-const CreatePollDialog = ({ userPollExists }: Props) => {
+const CreatePollDialog = ({ userPoll }: Props) => {
   const [open, setOpen] = useState(false);
   const { user } = ProtectedRoute.useRouteContext();
   const queryClient = useQueryClient();
   const getFoodsServer = useServerFn(getFoodsServerFn);
+  const createPollServer = useServerFn(createPollServerFn);
+
+  const existed = !!userPoll;
+  const disabled = userPoll?.closed_at !== null;
 
   const createPoll = useMutation({
-    mutationFn: createPollServerFn,
+    mutationFn: createPollServer,
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: listPollsTodayQueryKey(),
@@ -349,7 +354,7 @@ const CreatePollDialog = ({ userPollExists }: Props) => {
               />
             </FieldGroup>
           </div>
-          {userPollExists && (
+          {existed && !disabled && (
             <Alert variant="warning" appearance="light" className="mt-4">
               <AlertIcon>
                 <LucideAlertTriangle />
@@ -357,8 +362,21 @@ const CreatePollDialog = ({ userPollExists }: Props) => {
               <AlertContent>
                 <AlertTitle>Warning</AlertTitle>
                 <AlertDescription>
-                  A poll already exists for today, it will be replaced and all
-                  existing votes will be lost.
+                  A poll for tomorrow order already exists, it will be replaced
+                  and all existing votes will be lost.
+                </AlertDescription>
+              </AlertContent>
+            </Alert>
+          )}
+          {disabled && (
+            <Alert variant="destructive" appearance="light" className="mt-4">
+              <AlertIcon>
+                <LucideAlertTriangle />
+              </AlertIcon>
+              <AlertContent>
+                <AlertTitle>Error</AlertTitle>
+                <AlertDescription>
+                  You cannot replace a poll that has already been closed.
                 </AlertDescription>
               </AlertContent>
             </Alert>
@@ -374,7 +392,7 @@ const CreatePollDialog = ({ userPollExists }: Props) => {
               <Button
                 form="create-poll-form"
                 type="submit"
-                disabled={!canSubmit}
+                disabled={!canSubmit || disabled}
               >
                 {isSubmitting ?
                   <>

--- a/frontend/src/features/polls/components/poll-card.tsx
+++ b/frontend/src/features/polls/components/poll-card.tsx
@@ -1,5 +1,5 @@
 import { serverClient } from "@/api";
-import { postPollsByIdVote } from "@/client";
+import { GetTodayPollsQueryResponse, postPollsByIdVote } from "@/client";
 import { listPollsTodayQueryKey } from "@/client/@tanstack/react-query.gen";
 import { zPostPollsByIdVoteData } from "@/client/zod.gen";
 import CloseTimer from "@/components/close-timer";
@@ -8,6 +8,7 @@ import {
   Card,
   CardContent,
   CardDescription,
+  CardFooter,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
@@ -19,7 +20,7 @@ import { createServerFn } from "@tanstack/react-start";
 import { useEffect, useMemo } from "react";
 import { toast } from "sonner";
 import { z } from "zod";
-import PollOption, { Option } from "./poll-option";
+import PollOptionRadio from "./poll-option";
 import PollStrategyBadge from "./poll-strategy-badge";
 
 const castVoteServerFn = createServerFn({ method: "POST" })
@@ -39,28 +40,22 @@ const castVoteServerFn = createServerFn({ method: "POST" })
   });
 
 type Props = {
-  pollId: string;
-  buyerName: string;
-  avatarUrl: string;
-  scheduled_close_at: Date;
-  closed_at: Date | null;
-  strategy: "ORDER_CONSENSUS_ITEM" | "ORDER_PERSONAL_CHOICE";
-  options: Option[];
+  poll: GetTodayPollsQueryResponse;
 };
 
-const PollCard = ({
-  pollId,
-  buyerName,
-  avatarUrl,
-  scheduled_close_at,
-  closed_at,
-  strategy,
-  options,
-}: Props) => {
+const PollCard = ({ poll }: Props) => {
   const { user } = Route.useRouteContext();
+  const {
+    id,
+    creator: { display_name: buyerName, avatar_url: avatarUrl },
+    scheduled_closes_at,
+    closed_at,
+    strategy,
+    poll_options,
+  } = poll;
 
-  const initialSelectedOption = options?.find((option) =>
-    option.votes?.some((vote) => vote.userId === user.id)
+  const initialSelectedOption = poll_options?.find((option) =>
+    option.votes?.some((vote) => vote.voter?.id === user.id)
   );
 
   const queryClient = useQueryClient();
@@ -71,13 +66,13 @@ const PollCard = ({
         id: z
           .string()
           .nonempty({ message: "Please select an option" })
-          .refine((val) => options.some((option) => option.id === val), {
+          .refine((val) => poll_options.some((option) => option.id === val), {
             message: "Invalid option selected",
           }),
         isSelected: z.boolean(),
       }),
     });
-  }, [options]);
+  }, [poll_options]);
 
   const castVoteMutation = useMutation({
     mutationFn: castVoteServerFn,
@@ -115,7 +110,7 @@ const PollCard = ({
         .mutateAsync({
           data: {
             path: {
-              id: pollId,
+              id,
             },
             body: {
               poll_option_id: value.selectedOption.id,
@@ -139,7 +134,7 @@ const PollCard = ({
     >
       <Card>
         <CardHeader>
-          <CardTitle className="flex flex-col sm:flex-row text-lg">
+          <CardTitle className="flex flex-col justify-between items-center sm:flex-row text-lg">
             <div className="flex items-center gap-2">
               <Avatar className="size-8 sm:size-10">
                 <AvatarImage src={avatarUrl} />
@@ -149,14 +144,15 @@ const PollCard = ({
               </Avatar>
               <h3 className="text-base sm:text-lg leading-tight">
                 <span className="text-primary font-semibold">{buyerName}</span>{" "}
-                is buying breakfast
+                is buying breakfast for{" "}
+                {new Date(poll.order_date).toLocaleDateString("vi-VN")}
               </h3>
             </div>
           </CardTitle>
           <CardDescription className="mt-1 flex items-center justify-between text-sm sm:text-base">
             <CloseTimer
               className="text-sm sm:text-base shrink-0"
-              closesAt={closed_at || scheduled_close_at}
+              closesAt={closed_at || scheduled_closes_at}
             />
 
             <PollStrategyBadge strategy={strategy} />
@@ -169,8 +165,8 @@ const PollCard = ({
               children={(field) => {
                 return (
                   <div className={"grid grid-cols-1 lg:grid-cols-2 gap-3"}>
-                    {options.map((option) => (
-                      <PollOption
+                    {poll_options.map((option) => (
+                      <PollOptionRadio
                         key={option.id}
                         option={option}
                         disabled={!!closed_at}
@@ -199,6 +195,23 @@ const PollCard = ({
             />
           </FieldGroup>
         </CardContent>
+        <CardFooter>
+          <div className="flex flex-col sm:flex-row items-center justify-end w-full text-lg">
+            <span className="font-bold mr-2">Total Cost:</span>
+            <span className="font-medium text-slate-700">
+              {Intl.NumberFormat("vi-VN", {
+                style: "currency",
+                currency: "VND",
+              }).format(
+                poll_options.reduce(
+                  (acc, option) =>
+                    acc + option.price_at_creation * (option.votes.length || 0),
+                  0
+                )
+              )}
+            </span>
+          </div>
+        </CardFooter>
       </Card>
     </form>
   );

--- a/frontend/src/features/polls/components/poll-option.tsx
+++ b/frontend/src/features/polls/components/poll-option.tsx
@@ -1,41 +1,29 @@
+import { PollOption } from "@/client";
 import {
   AvatarGroup,
   AvatarGroupTooltip,
 } from "@/components/animate-ui/components/animate/avatar-group";
-import { FoodImage } from "@/features/foods/components/food-image";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Label } from "@/components/ui/label";
+import { FoodImage } from "@/features/foods/components/food-image";
 import { cn } from "@/lib/utils";
 import { Circle } from "lucide-react";
 import TablerCurrencyDong from "~icons/tabler/currency-dong?width=2em&height=2em";
 
-export type Vote = {
-  userId: string;
-  userName: string;
-  userAvatarUrl: string;
-};
-
-export type Option = {
-  id: string;
-  foodName: string;
-  foodImageUrl: string;
-  price: number;
-  votes: Vote[];
-};
-
 type Props = {
-  option: Option;
+  option: PollOption;
   onSelect?: (id: string) => void;
   isSelected?: boolean;
   disabled?: boolean;
 };
 
-function PollOption({
+function PollOptionRadio({
   option,
   onSelect,
   isSelected = false,
   disabled = false,
 }: Props) {
+  console.log(disabled);
   return (
     <div
       key={option.id}
@@ -44,16 +32,16 @@ function PollOption({
         {
           "border-primary shadow-lg": isSelected,
           "hover:border-zinc-400": !isSelected && !disabled,
-          "opacity-60": disabled,
+          "opacity-50 cursor-not-allowed": disabled,
         }
       )}
       onClick={() => !disabled && onSelect?.(option.id)}
     >
       <div className="h-40 sm:h-48 bg-slate-100 overflow-hidden relative">
-        <FoodImage src={option.foodImageUrl} alt={option.foodName} />
+        <FoodImage src={""} alt={option.food.name} />
         <div className="absolute top-2 left-2 bg-white/90 backdrop-blur px-2 py-0.5 sm:px-3 sm:py-1 rounded-full flex items-center gap-0.5 shadow">
           <span className="text-slate-900 font-medium text-xs sm:text-sm">
-            {new Intl.NumberFormat("vi-VN").format(option.price)}
+            {new Intl.NumberFormat("vi-VN").format(option.price_at_creation)}
           </span>
           <TablerCurrencyDong className="size-4 sm:size-4.5 text-green-500" />
         </div>
@@ -72,23 +60,32 @@ function PollOption({
           </div>
           <Label
             htmlFor={`option-${option.id}`}
-            className={`flex-1 cursor-pointer text-base sm:text-lg ${false ? "text-slate-900" : "text-slate-700"}`}
+            className={cn(
+              "flex-1 text-base sm:text-lg",
+              disabled ?
+                "cursor-not-allowed text-slate-400"
+              : "cursor-pointer text-slate-900"
+            )}
           >
-            {option.foodName}
+            {option.food.name}
           </Label>
         </div>
-
         {/* Show current voters */}
         {option.votes.length > 0 && (
           <div className="flex flex-col gap-1 self-end items-end">
             <AvatarGroup>
               {option.votes.map((vote, index) => (
                 <Avatar key={index}>
-                  <AvatarImage src={vote.userAvatarUrl} />
+                  <AvatarImage
+                    src={vote.voter.avatar_url}
+                    alt={vote.voter.avatar_url}
+                  />
                   <AvatarFallback>
-                    {vote.userName.substring(0, 2).toUpperCase()}
+                    {vote.voter.display_name.substring(0, 2).toUpperCase()}
                   </AvatarFallback>
-                  <AvatarGroupTooltip>{vote.userName}</AvatarGroupTooltip>
+                  <AvatarGroupTooltip>
+                    {vote.voter.display_name}
+                  </AvatarGroupTooltip>
                 </Avatar>
               ))}
             </AvatarGroup>
@@ -131,4 +128,4 @@ function PollOption({
   );
 }
 
-export default PollOption;
+export default PollOptionRadio;

--- a/frontend/src/lib/centrifugo/centrifugo-context.tsx
+++ b/frontend/src/lib/centrifugo/centrifugo-context.tsx
@@ -53,7 +53,7 @@ export const CentrifugoProvider: React.FC<Props> = ({ children }) => {
       getToken: async () => {
         try {
           const res = await getCentrifugoToken();
-          return res.token;
+          return res.data?.token ?? "";
         } catch (error) {
           console.error("Error fetching Centrifugo token:", error);
           return "";

--- a/frontend/src/lib/centrifugo/get-centrifugo-token-server-fn.ts
+++ b/frontend/src/lib/centrifugo/get-centrifugo-token-server-fn.ts
@@ -8,7 +8,10 @@ export const getCentrifugoTokenServerFn = createServerFn({
   const resp = await getAuthCentrifugoToken({ client: serverClient });
   if (resp.error) {
     console.error("Failed to get Centrifugo token:", resp.error);
-    throw new Error("Failed to get Centrifugo token");
+    return {
+      error:
+        resp.error.errors?.at(0)?.message ?? "Failed to get Centrifugo token",
+    };
   }
-  return resp.data;
+  return { data: resp.data };
 });

--- a/frontend/src/routes/_protected/foods/index.tsx
+++ b/frontend/src/routes/_protected/foods/index.tsx
@@ -36,7 +36,9 @@ function Foods() {
       <div className="flex justify-end">
         <AddFoodDialog />
       </div>
-      <DataTable columns={columns} data={data ?? []} />
+      <div className="rounded-lg">
+        <DataTable columns={columns} data={data ?? []} />
+      </div>
     </div>
   );
 }

--- a/frontend/src/routes/_protected/index.tsx
+++ b/frontend/src/routes/_protected/index.tsx
@@ -14,6 +14,8 @@ import MealCard from "@/features/orders/components/meal-card";
 import ShoppingCard from "@/features/orders/components/shopping-card";
 import { createFileRoute, Link, redirect } from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
+import { useEffect } from "react";
+import { toast } from "sonner";
 import z from "zod";
 import LucideSandwich from "~icons/lucide/sandwich";
 
@@ -90,18 +92,40 @@ export const Route = createFileRoute("/_protected/")({
       }),
     ]);
 
+    console.log("Loader fetched ordered items and shopping order", {
+      orderedItemsRes,
+      shoppingOrderRes,
+    });
+
     return {
-      orderedItems: orderedItemsRes.data,
+      orderedItems: orderedItemsRes.data?.items || [],
       shoppingOrder: shoppingOrderRes.data,
+      error: orderedItemsRes.error || shoppingOrderRes.error,
     };
   },
 });
 
 function Index() {
-  const empty = false;
+  const { orderedItems, shoppingOrder, error } = Route.useLoaderData();
+
+  useEffect(() => {
+    if (error) {
+      console.error("Error loading data:", error);
+      toast.error(`Error loading data: ${error}`);
+    }
+  }, [error]);
+
+  if (!!error) {
+    return (
+      <div className="container mx-auto py-6 px-6 md:p-10 max-w-4xl">
+        <p className="text-red-600">Error loading data: {error}</p>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col gap-6">
-      {empty ?
+      {orderedItems.length === 0 ?
         <Card>
           <Empty>
             <EmptyHeader>
@@ -120,9 +144,9 @@ function Index() {
             </EmptyContent>
           </Empty>
         </Card>
-      : <MealCard />}
+      : <MealCard orderedItems={orderedItems} />}
 
-      <ShoppingCard />
+        {shoppingOrder && <ShoppingCard shoppingOrder={shoppingOrder} />}
     </div>
   );
 }

--- a/frontend/src/routes/_protected/polls/today/index.tsx
+++ b/frontend/src/routes/_protected/polls/today/index.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { listPollsTodayServerFn } from "@/features/polls/api/get-today-polls";
 import CreatePollDialog from "@/features/polls/components/create-poll-dialog";
 import PollCard from "@/features/polls/components/poll-card";
+import { CentrifugoProvider } from "@/lib/centrifugo/centrifugo-context";
 import { useSubscription } from "@/lib/centrifugo/use-subscription";
 import { QueryClient, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
@@ -17,28 +18,42 @@ export const Route = createFileRoute("/_protected/polls/today/")({
       pageTitle: "Today's Polls",
     };
   },
-  loader: async ({ abortController, context }) => {
-    const polls = await listPollsTodayServerFn({
+  loader: async ({ abortController }) => {
+    const res = await listPollsTodayServerFn({
       signal: abortController.signal,
     });
-    // Pre-populate query cache for instant hydration
-    context.queryClient.setQueryData(listPollsTodayQueryKey(), polls);
-    return { polls };
+    return { polls: res.data || [], error: res.error };
   },
 });
 
 function RouteComponent() {
+  return (
+    <CentrifugoProvider>
+      <PollsContent />
+    </CentrifugoProvider>
+  );
+}
+
+function PollsContent() {
   const { polls } = Route.useLoaderData();
   const { user } = Route.useRouteContext();
+  console.log("polls loader data", polls);
 
   const queryClient = useQueryClient();
 
   // Wrap server function for client-side use
   const fetchPolls = useServerFn(listPollsTodayServerFn);
 
-  const { data = polls } = useQuery({
+  const { data } = useQuery({
     queryKey: listPollsTodayQueryKey(),
-    queryFn: () => fetchPolls(),
+    queryFn: async () => {
+      const res = await fetchPolls();
+      if (res.error) {
+        toast.error(res.error);
+        throw new Error(res.error);
+      }
+      return res.data || [];
+    },
     initialData: polls,
     staleTime: 30000, // Consider data fresh for 30s to prevent immediate refetch
   });
@@ -50,7 +65,12 @@ function RouteComponent() {
       <div className="flex flex-col gap-3">
         <div className="flex w-full flex-col items-center justify-end gap-3 sm:flex-row">
           <CreatePollDialog
-            userPollExists={data?.some((poll) => poll.creator?.id === user?.id)}
+            userPoll={data.find(
+              (poll) =>
+                poll.creator?.id === user?.id &&
+                new Date(poll.order_date).toISOString().split("T")[0] ===
+                  new Date().toISOString().split("T")[0]
+            )}
           />
         </div>
 
@@ -83,31 +103,7 @@ function RouteComponent() {
 
       <div className="grid grid-cols-1 gap-6">
         {data?.map((poll) => {
-          return (
-            <PollCard
-              key={poll.id}
-              pollId={poll.id}
-              avatarUrl={poll.creator?.avatar_url}
-              buyerName={poll.creator?.display_name || "Unknown"}
-              scheduled_close_at={new Date(poll.scheduled_closes_at)}
-              closed_at={poll.closed_at ? new Date(poll.closed_at) : null}
-              strategy={poll.strategy as any}
-              options={
-                poll.poll_options?.map((option) => ({
-                  id: option.id || "",
-                  foodName: option.food?.name || "Unknown Food",
-                  foodImageUrl: "",
-                  price: option.price_at_creation || 0,
-                  votes:
-                    option.votes?.map((vote) => ({
-                      userId: vote.voter?.id || "",
-                      userName: vote.voter?.display_name || "Unknown",
-                      userAvatarUrl: vote.voter?.avatar_url,
-                    })) || [],
-                })) || []
-              }
-            />
-          );
+          return <PollCard key={poll.id} poll={poll} />;
         })}
       </div>
     </div>

--- a/frontend/src/routes/_protected/route.tsx
+++ b/frontend/src/routes/_protected/route.tsx
@@ -4,7 +4,6 @@ import {
   SidebarTrigger,
 } from "@/components/animate-ui/components/radix/sidebar";
 import AppSidebar from "@/components/app-sidebar";
-import { CentrifugoProvider } from "@/lib/centrifugo/centrifugo-context";
 import { fetchUser } from "@/lib/fetch-user-server-fn";
 import { ProtectedRouteContext } from "@/types/route-context";
 import {
@@ -37,21 +36,19 @@ function ProtectedLayout() {
   };
 
   return (
-    <CentrifugoProvider>
-      <SidebarProvider>
-        <AppSidebar />
-        <SidebarInset>
-          <SidebarTrigger className="size-12" />
-          <div className="container mx-auto py-6 px-6 md:p-10 max-w-4xl">
-            {context.pageTitle && (
-              <div className="mb-6">
-                <h1 className="text-3xl font-bold">{context.pageTitle}</h1>
-              </div>
-            )}
-            <Outlet />
-          </div>
-        </SidebarInset>
-      </SidebarProvider>
-    </CentrifugoProvider>
+    <SidebarProvider>
+      <AppSidebar />
+      <SidebarInset>
+        <SidebarTrigger className="size-12" />
+        <div className="container mx-auto py-6 px-6 md:p-10 max-w-4xl">
+          {context.pageTitle && (
+            <div className="mb-6">
+              <h1 className="text-3xl font-bold">{context.pageTitle}</h1>
+            </div>
+          )}
+          <Outlet />
+        </div>
+      </SidebarInset>
+    </SidebarProvider>
   );
 }


### PR DESCRIPTION
- Align API generation and runtime defaults to treat arrays as 
non-nullable   by setting huma.DefaultArrayNullable = false in the 
server bootstrap.   This ensures arrays emitted by the API are always 
arrays (not null). - Update multiple response and request DTOs to 
reflect non-nullable arrays   and explicit nullability for single 
fields:   - Backend: mark Items in GetOrderedItemsResponse with 
`nullable:"false"`.   - Backend: make GetFoodsQueryResponse.ImageURL be 
present (no omitempty). - Regenerate frontend TypeScript/Zod client 
schemas to match the new   non-nullable semantics:
-   - Replace union([array(...), null]) with array(...) for collections 
ed     across clients (providers, food_ids, errors, details, 
order_items,     items, users, votes, poll_options, etc.).
-   - Add explicit nullable union for single optional strings where 
eded     (e.g. image_url: string | null).
-   - Tighten array constraints (min(1)) where applicable to preserve
-     validation rules.
-   - Adjust enums and field ordering to reflect updated API shapes.
- - Reorder minor imports in server.go to keep formatting consistent.
- Why:
- - Prevents ambiguity between null and empty arrays across backend and
-   frontend, simplifying validation and client code.
- - Keeps generated client schemas in sync with backend contracts to 
- oid
  runtime type mismatches and improve developer ergonomics.