### PR TITLE
✨ feat: add dev debug setup and logout click handler

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,14 +2,57 @@
   // Use IntelliSense to learn about possible attributes.
   // Hover to view descriptions of existing attributes.
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Attach to Process",
+      "name": "Connect to Docker Backend",
       "type": "go",
       "request": "attach",
-      "mode": "local",
-      "processId": 0
+      "mode": "remote",
+      "port": 40000,
+      "host": "localhost",
+      "substitutePath": [
+        {
+          "from": "${workspaceFolder}",
+          "to": "/app"
+        }
+      ],
+      "showLog": true,
+      "trace": "verbose"
+    },
+    {
+      "name": "Debug Frontend (Chrome)",
+      "type": "chrome",
+      "request": "launch",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}/frontend",
+      "sourceMapPathOverrides": {
+        "/*": "${workspaceFolder}/frontend/*"
+      }
+    },
+    {
+      "name": "Debug Frontend (Firefox)",
+      "type": "firefox",
+      "request": "launch",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}/frontend",
+      "pathMappings": [
+        {
+          "url": "webpack:///",
+          "path": "${workspaceFolder}/frontend/"
+        }
+      ]
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Debug Full Stack",
+      "configurations": [
+        "Connect to Docker Backend",
+        "Debug Frontend (Chrome)"
+      ],
+      "stopAll": true
     }
   ]
 }

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,0 +1,16 @@
+FROM golang:1-alpine
+
+ENV CGO_ENABLED=0
+
+WORKDIR /app
+
+RUN go install github.com/bokwoon95/wgo@latest
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+
+COPY go.mod .
+COPY go.sum .
+COPY ./backend ./backend
+
+EXPOSE 8080 40000
+
+CMD sh -c "wgo -file .go go build -gcflags 'all=-N -l' -o main ./backend/cmd/ :: dlv exec --headless --listen=:40000 --api-version=2 --accept-multiclient --continue ./main"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,9 +10,6 @@ services:
       - .env
     environment:
       - CHOKIDAR_USEPOLLING=true
-    depends_on:
-      backend:
-        condition: service_healthy
     ports:
       - 3000:3000
     volumes:
@@ -21,11 +18,13 @@ services:
     restart: on-failure
 
   backend:
-    image: cosmtrek/air
-    working_dir: /app
+    build:
+      context: .
+      dockerfile: ./backend/Dockerfile.dev
     container_name: backend
     ports:
       - 8080:8080
+      - 40000:40000
     env_file:
       - .env
     depends_on:
@@ -35,10 +34,8 @@ services:
         condition: service_healthy
     volumes:
       - ./backend/:/app/backend/
-      - /app/backend/tmp
       - ./go.mod:/app/go.mod
       - ./go.sum:/app/go.sum
-      - ./.air.toml:/app/.air.toml
     restart: on-failure
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/livez"]

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -179,7 +179,9 @@ const AppSidebar = () => {
                   </DropdownMenuItem>
                 </DropdownMenuGroup>
                 <DropdownMenuSeparator />
-                <DropdownMenuItem>
+                <DropdownMenuItem onClick={(e) => {
+                  console.log("Logout")
+                }}>
                   <LogOut />
                   Log out
                 </DropdownMenuItem>


### PR DESCRIPTION
Summary

- Add dev debug setup and logout click handler to prepare for implementing logout flow.

What changed

- Add onClick logging for the sidebar "Log out" menu item.
- Replace backend Docker image with Dockerfile.dev to run the app under Delve for remote debugging.
- Expose Delve debug port 40000 and forward it in docker-compose for editor attachment.
- Add backend bind mount cleanup and mount go.mod/go.sum for live development.
- Remove frontend health check dependency to simplify startup ordering during iterative development.
- Add VS Code launch configurations: Go remote attach, Chrome/Firefox frontend debug, and a compound "Debug Full Stack" config.
- Add backend/Dockerfile.dev that installs delve and runs the binary under dlv.

Notes

- These changes enable full-stack local debugging and set up groundwork for the logout handler.