### PR TITLE
✨ feat(modal): add unified Modal component with responsive

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -67,6 +67,7 @@
         "react-day-picker": "^9.11.3",
         "react-dom": "^19.2.0",
         "react-dropzone": "^14.3.8",
+        "react-easy-crop": "^5.5.6",
         "react-hook-form": "^7.67.0",
         "react-medium-image-zoom": "^5.4.0",
         "shadcn": "^3.5.1",
@@ -76,6 +77,7 @@
         "tailwind-merge": "^3.4.0",
         "tailwindcss": "^4.1.17",
         "tw-animate-css": "^1.4.0",
+        "vaul": "^1.1.2",
         "vite-tsconfig-paths": "^5.1.4",
         "zod": "^4.1.13",
       },
@@ -1427,6 +1429,8 @@
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 
+    "normalize-wheel": ["normalize-wheel@1.0.1", "", {}, "sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA=="],
+
     "npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
 
     "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
@@ -1552,6 +1556,8 @@
     "react-dom": ["react-dom@19.2.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ=="],
 
     "react-dropzone": ["react-dropzone@14.3.8", "", { "dependencies": { "attr-accept": "^2.2.4", "file-selector": "^2.1.0", "prop-types": "^15.8.1" }, "peerDependencies": { "react": ">= 16.8 || 18.0.0" } }, "sha512-sBgODnq+lcA4P296DY4wacOZz3JFpD99fp+hb//iBO2HHnyeZU3FwWyXJ6salNpqQdsZrgMrotuko/BdJMV8Ug=="],
+
+    "react-easy-crop": ["react-easy-crop@5.5.6", "", { "dependencies": { "normalize-wheel": "^1.0.1", "tslib": "^2.0.1" }, "peerDependencies": { "react": ">=16.4.0", "react-dom": ">=16.4.0" } }, "sha512-Jw3/ozs8uXj3NpL511Suc4AHY+mLRO23rUgipXvNYKqezcFSYHxe4QXibBymkOoY6oOtLVMPO2HNPRHYvMPyTw=="],
 
     "react-hook-form": ["react-hook-form@7.67.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-E55EOwKJHHIT/I6J9DmQbCWToAYSw9nN5R57MZw9rMtjh+YQreMDxRLfdjfxQbiJ3/qbg3Z02wGzBX4M+5fMtQ=="],
 
@@ -1776,6 +1782,8 @@
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "vaul": ["vaul@1.1.2", "", { "dependencies": { "@radix-ui/react-dialog": "^1.1.1" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA=="],
 
     "vite": ["vite@7.2.6", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ=="],
 

--- a/frontend/components.json
+++ b/frontend/components.json
@@ -24,6 +24,7 @@
     "@reui": "https://reui.io/r/{name}.json",
     "@blocks": "https://blocks.so/r/{name}.json",
     "@eo-n": "https://eo-n.vercel.app/r/{name}",
-    "@wds": "https://wds-shadcn-registry.netlify.app/r/{name}.json"
+    "@wds": "https://wds-shadcn-registry.netlify.app/r/{name}.json",
+    "@diceui": "https://diceui.com/r/{name}.json"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -79,6 +79,7 @@
     "react-day-picker": "^9.11.3",
     "react-dom": "^19.2.0",
     "react-dropzone": "^14.3.8",
+    "react-easy-crop": "^5.5.6",
     "react-hook-form": "^7.67.0",
     "react-medium-image-zoom": "^5.4.0",
     "shadcn": "^3.5.1",
@@ -88,6 +89,7 @@
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.17",
     "tw-animate-css": "^1.4.0",
+    "vaul": "^1.1.2",
     "vite-tsconfig-paths": "^5.1.4",
     "zod": "^4.1.13"
   },

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -1,8 +1,17 @@
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuGroup,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@/components/animate-ui/components/radix/dropdown-menu";
 import useIsMobile from "@/hooks/use-is-mobile";
 import { createSupabaseClient } from "@/lib/supabase";
 import { fetchUser } from "@/lib/supabase/fetch-user-server-fn";
 import { useQuery } from "@tanstack/react-query";
-import { Link, LinkOptions, useNavigate } from "@tanstack/react-router";
+import { Link, type LinkOptions, useNavigate } from "@tanstack/react-router";
 import { useServerFn } from "@tanstack/react-start";
 import { BadgeCheck, Bell, ChevronsUpDown, LogOut } from "lucide-react";
 import React from "react";
@@ -10,209 +19,200 @@ import FluentFood32Filled from "~icons/fluent/food-32-filled";
 import FluentHome32Filled from "~icons/fluent/home-32-filled";
 import LucideVote from "~icons/lucide/vote?width=2em&height=2em";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuGroup,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "./animate-ui/components/radix/dropdown-menu";
-import {
-  Sidebar,
-  SidebarContent,
-  SidebarFooter,
-  SidebarGroup,
-  SidebarHeader,
-  SidebarMenu,
-  SidebarMenuButton,
-  SidebarMenuItem,
-  SidebarRail,
+	Sidebar,
+	SidebarContent,
+	SidebarFooter,
+	SidebarGroup,
+	SidebarHeader,
+	SidebarMenu,
+	SidebarMenuButton,
+	SidebarMenuItem,
+	SidebarRail,
 } from "./animate-ui/components/radix/sidebar";
 import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
 
 type NavData = {
-  linkOptions: LinkOptions;
-  label: string;
-  icon: React.FC<React.SVGProps<SVGSVGElement>>;
+	linkOptions: LinkOptions;
+	label: string;
+	icon: React.FC<React.SVGProps<SVGSVGElement>>;
 };
 
 const DATA: NavData[] = [
-  {
-    linkOptions: {
-      to: "/",
-    },
-    label: "Home",
-    icon: FluentHome32Filled,
-  },
-  {
-    linkOptions: {
-      to: "/polls/today",
-    },
-    label: "Today Polls",
-    icon: LucideVote,
-  },
-  {
-    linkOptions: {
-      to: "/foods",
-    },
-    label: "Foods",
-    icon: FluentFood32Filled,
-  },
+	{
+		linkOptions: {
+			to: "/",
+		},
+		label: "Home",
+		icon: FluentHome32Filled,
+	},
+	{
+		linkOptions: {
+			to: "/polls/today",
+		},
+		label: "Today Polls",
+		icon: LucideVote,
+	},
+	{
+		linkOptions: {
+			to: "/foods",
+		},
+		label: "Foods",
+		icon: FluentFood32Filled,
+	},
 ];
 
 const AppSidebar = () => {
-  const { isMobile } = useIsMobile();
-  const getUser = useServerFn(fetchUser);
-  const navigate = useNavigate();
+	const { isMobile } = useIsMobile();
+	const getUser = useServerFn(fetchUser);
+	const navigate = useNavigate();
 
-  const logOut: React.MouseEventHandler<HTMLDivElement> = async (e) => {
-    e.preventDefault();
-    const supabase = await createSupabaseClient();
-    supabase.auth.signOut().then(() => {
-      navigate({ to: "/login" });
-    });
-  };
+	const logOut: React.MouseEventHandler<HTMLDivElement> = async (e) => {
+		e.preventDefault();
+		const supabase = await createSupabaseClient();
+		supabase.auth.signOut().then(() => {
+			navigate({ to: "/login" });
+		});
+	};
 
-  const { data: user } = useQuery({
-    queryKey: ["user"],
-    queryFn: getUser,
-  });
+	const { data: user } = useQuery({
+		queryKey: ["user"],
+		queryFn: getUser,
+	});
 
-  return (
-    <Sidebar>
-      <SidebarHeader>
-        {/* Team Switcher */}
-        <SidebarMenu>
-          <SidebarMenuItem>
-            {/* <SidebarMenuButton
+	return (
+		<Sidebar>
+			<SidebarHeader>
+				{/* Team Switcher */}
+				<SidebarMenu>
+					<SidebarMenuItem>
+						{/* <SidebarMenuButton
               size="lg"
               className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
             > */}
-            {/* <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground">
+						{/* <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground">
                 <activeTeam.logo className="size-4" />
               </div> */}
-            <Link
-              to="/"
-              className="grid flex-1 text-center text-xl leading-tight"
-            >
-              <span className="truncate font-semibold">WEEATE</span>
-              {/* <span className="truncate text-xs">{activeTeam.plan}</span> */}
-            </Link>
-            {/* <ChevronsUpDown className="ml-auto" /> */}
-            {/* </SidebarMenuButton> */}
-          </SidebarMenuItem>
-        </SidebarMenu>
-        {/* Team Switcher */}
-      </SidebarHeader>
+						<Link
+							to="/"
+							className="grid flex-1 text-center text-xl leading-tight"
+						>
+							<span className="truncate font-semibold">WEEATE</span>
+							{/* <span className="truncate text-xs">{activeTeam.plan}</span> */}
+						</Link>
+						{/* <ChevronsUpDown className="ml-auto" /> */}
+						{/* </SidebarMenuButton> */}
+					</SidebarMenuItem>
+				</SidebarMenu>
+				{/* Team Switcher */}
+			</SidebarHeader>
 
-      <SidebarContent>
-        <SidebarGroup>
-          <SidebarMenu>
-            {DATA.map((item, i) => (
-              <SidebarMenuItem key={i}>
-                <SidebarMenuButton asChild size="lg">
-                  <Link
-                    {...item.linkOptions}
-                    className="rounded-lg px-3 py-2 text-xl font-medium text-muted-foreground transition-colors hover:text-foreground [&.active]:bg-primary/10 [&.active]:text-primary"
-                  >
-                    <item.icon className="mr-3 size-6!" />
-                    <span>{item.label}</span>
-                  </Link>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            ))}
-          </SidebarMenu>
-        </SidebarGroup>
-      </SidebarContent>
-      <SidebarFooter>
-        {/* Nav User */}
-        <SidebarMenu>
-          <SidebarMenuItem>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <SidebarMenuButton
-                  size="lg"
-                  className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
-                >
-                  <Avatar className="h-8 w-8 rounded-lg">
-                    <AvatarImage
-                      src={user?.app_metadata.avatar_url}
-                      alt={user?.app_metadata.display_name}
-                    />
-                    <AvatarFallback className="rounded-lg">
-                      {user?.email?.substring(0, 2).toUpperCase()}
-                    </AvatarFallback>
-                  </Avatar>
-                  <div className="grid flex-1 text-left text-sm leading-tight">
-                    <span className="truncate font-semibold">
-                      {user?.app_metadata.display_name || "Unnamed User"}
-                    </span>
-                    <span className="truncate text-xs">{user?.email}</span>
-                  </div>
-                  <ChevronsUpDown className="ml-auto size-4" />
-                </SidebarMenuButton>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent
-                className="w-[--radix-dropdown-menu-trigger-width] min-w-56 rounded-lg"
-                side={isMobile ? "bottom" : "right"}
-                align="end"
-                sideOffset={4}
-              >
-                <DropdownMenuLabel className="p-0 font-normal">
-                  <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
-                    <Avatar className="h-8 w-8 rounded-lg">
-                      <AvatarImage
-                        src={user?.app_metadata.avatar_url}
-                        alt={user?.app_metadata.display_name}
-                      />
-                      <AvatarFallback className="rounded-lg">
-                        {user?.email?.substring(0, 2).toUpperCase()}
-                      </AvatarFallback>
-                    </Avatar>
-                    <div className="grid flex-1 text-left text-sm leading-tight">
-                      <span className="truncate font-semibold">
-                        {user?.app_metadata.display_name || "Unnamed User"}
-                      </span>
-                      <span className="truncate text-xs">{user?.email}</span>
-                    </div>
-                  </div>
-                </DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                <DropdownMenuGroup>
-                  <DropdownMenuItem>
-                    <Link
-                      to="/account"
-                      className="flex gap-2 items-center w-full"
-                    >
-                      <BadgeCheck />
-                      Account
-                    </Link>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem>
-                    <Link
-                      to="/notifications"
-                      className="flex gap-2 items-center w-full"
-                    >
-                      <Bell />
-                      Notifications
-                    </Link>
-                  </DropdownMenuItem>
-                </DropdownMenuGroup>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={logOut}>
-                  <LogOut />
-                  Log out
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </SidebarMenuItem>
-        </SidebarMenu>
-        {/* Nav User */}
-      </SidebarFooter>
-      <SidebarRail />
-    </Sidebar>
-  );
+			<SidebarContent>
+				<SidebarGroup>
+					<SidebarMenu>
+						{DATA.map((item) => (
+							<SidebarMenuItem key={item.label}>
+								<SidebarMenuButton asChild size="lg">
+									<Link
+										{...item.linkOptions}
+										className="rounded-lg px-3 py-2 text-xl font-medium text-muted-foreground transition-colors hover:text-foreground [&.active]:bg-primary/10 [&.active]:text-primary"
+									>
+										<item.icon className="mr-3 size-6!" />
+										<span>{item.label}</span>
+									</Link>
+								</SidebarMenuButton>
+							</SidebarMenuItem>
+						))}
+					</SidebarMenu>
+				</SidebarGroup>
+			</SidebarContent>
+			<SidebarFooter>
+				{/* Nav User */}
+				<SidebarMenu>
+					<SidebarMenuItem>
+						<DropdownMenu>
+							<DropdownMenuTrigger asChild>
+								<SidebarMenuButton
+									size="lg"
+									className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+								>
+									<Avatar className="h-8 w-8 rounded-lg">
+										<AvatarImage
+											src={user?.app_metadata.avatar_url}
+											alt={user?.app_metadata.display_name}
+										/>
+										<AvatarFallback className="rounded-lg">
+											{user?.email?.substring(0, 2).toUpperCase()}
+										</AvatarFallback>
+									</Avatar>
+									<div className="grid flex-1 text-left text-sm leading-tight">
+										<span className="truncate font-semibold">
+											{user?.app_metadata.display_name || "Unnamed User"}
+										</span>
+										<span className="truncate text-xs">{user?.email}</span>
+									</div>
+									<ChevronsUpDown className="ml-auto size-4" />
+								</SidebarMenuButton>
+							</DropdownMenuTrigger>
+							<DropdownMenuContent
+								className="w-[--radix-dropdown-menu-trigger-width] min-w-56 rounded-lg"
+								side={isMobile ? "bottom" : "right"}
+								align="end"
+								sideOffset={4}
+							>
+								<DropdownMenuLabel className="p-0 font-normal">
+									<div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
+										<Avatar className="h-8 w-8 rounded-lg">
+											<AvatarImage
+												src={user?.app_metadata.avatar_url}
+												alt={user?.app_metadata.display_name}
+											/>
+											<AvatarFallback className="rounded-lg">
+												{user?.email?.substring(0, 2).toUpperCase()}
+											</AvatarFallback>
+										</Avatar>
+										<div className="grid flex-1 text-left text-sm leading-tight">
+											<span className="truncate font-semibold">
+												{user?.app_metadata.display_name || "Unnamed User"}
+											</span>
+											<span className="truncate text-xs">{user?.email}</span>
+										</div>
+									</div>
+								</DropdownMenuLabel>
+								<DropdownMenuSeparator />
+								<DropdownMenuGroup>
+									<DropdownMenuItem>
+										<Link
+											to="/account"
+											className="flex gap-2 items-center w-full"
+										>
+											<BadgeCheck />
+											Account
+										</Link>
+									</DropdownMenuItem>
+									<DropdownMenuItem>
+										<Link
+											to="/notifications"
+											className="flex gap-2 items-center w-full"
+										>
+											<Bell />
+											Notifications
+										</Link>
+									</DropdownMenuItem>
+								</DropdownMenuGroup>
+								<DropdownMenuSeparator />
+								<DropdownMenuItem onClick={logOut}>
+									<LogOut />
+									Log out
+								</DropdownMenuItem>
+							</DropdownMenuContent>
+						</DropdownMenu>
+					</SidebarMenuItem>
+				</SidebarMenu>
+				{/* Nav User */}
+			</SidebarFooter>
+			<SidebarRail />
+		</Sidebar>
+	);
 };
 
 export default AppSidebar;

--- a/frontend/src/components/avatar-upload.tsx
+++ b/frontend/src/components/avatar-upload.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import { Alert, AlertContent, AlertDescription, AlertIcon, AlertTitle } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { formatBytes, useFileUpload, type FileWithPreview } from '@/hooks/use-file-upload'
+import { cn } from '@/lib/utils'
+import { TriangleAlert, User, X } from 'lucide-react'
+
+interface AvatarUploadProps {
+  maxSize?: number
+  className?: string
+  onFileChange?: (file: FileWithPreview | null) => void
+  defaultAvatar?: string
+}
+
+export default function AvatarUpload({
+  maxSize = 2 * 1024 * 1024, // 2MB
+  className,
+  onFileChange,
+  defaultAvatar,
+}: AvatarUploadProps) {
+  const [
+    { files, isDragging, errors },
+    { removeFile, handleDragEnter, handleDragLeave, handleDragOver, handleDrop, openFileDialog, getInputProps, clearFiles, addFiles },
+  ] = useFileUpload({
+    maxFiles: 1,
+    maxSize,
+    accept: 'image/*',
+    multiple: false,
+    onFilesChange: (files) => {
+      onFileChange?.(files[0] || null)
+    },
+  })
+
+  const currentFile = files[0]
+  const previewUrl = currentFile?.preview || defaultAvatar
+
+  const handleRemove = () => {
+    if (currentFile) {
+      removeFile(currentFile.id)
+    }
+  }
+
+  return (
+    <div className={cn('flex flex-col items-center gap-4', className)}>
+      {/* Avatar Preview */}
+      <div className="relative">
+        <div
+          className={cn(
+            'group/avatar relative h-24 w-24 cursor-pointer overflow-hidden rounded-full border border-dashed transition-colors',
+            isDragging ? 'border-primary bg-primary/5' : 'border-muted-foreground/25 hover:border-muted-foreground/20',
+            previewUrl && 'border-solid',
+          )}
+          onDragEnter={handleDragEnter}
+          onDragLeave={handleDragLeave}
+          onDragOver={handleDragOver}
+          onDrop={handleDrop}
+          onClick={openFileDialog}
+        >
+          <input {...getInputProps()} className="sr-only" />
+
+          {previewUrl ? (
+            <img src={previewUrl} alt="Avatar" className="h-full w-full object-cover" />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center">
+              <User className="size-6 text-muted-foreground" />
+            </div>
+          )}
+        </div>
+
+        {/* Remove Button - only show when file is uploaded */}
+        {currentFile && (
+          <Button
+            size="icon"
+            variant="outline"
+            onClick={handleRemove}
+            className="size-6 absolute end-0 top-0 rounded-full"
+            aria-label="Remove avatar"
+          >
+            <X className="size-3.5" />
+          </Button>
+        )}
+      </div>
+
+      {/* Upload Instructions */}
+      <div className="text-center space-y-0.5">
+        <p className="text-sm font-medium">{currentFile ? 'Avatar uploaded' : 'Upload avatar'}</p>
+        <p className="text-xs text-muted-foreground">PNG, JPG up to {formatBytes(maxSize)}</p>
+      </div>
+
+      {/* Error Messages */}
+      {errors.length > 0 && (
+        <Alert variant="destructive" appearance="light" className="mt-5">
+          <AlertIcon>
+            <TriangleAlert />
+          </AlertIcon>
+          <AlertContent>
+            <AlertTitle>File upload error(s)</AlertTitle>
+            <AlertDescription>
+              {errors.map((error, index) => (
+                <p key={index} className="last:mb-0">
+                  {error}
+                </p>
+              ))}
+            </AlertDescription>
+          </AlertContent>
+        </Alert>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/avatar-uploader.tsx
+++ b/frontend/src/components/avatar-uploader.tsx
@@ -1,0 +1,265 @@
+'use client';
+
+import React from 'react';
+import Cropper, { Area, Point } from 'react-easy-crop';
+import {
+	Modal,
+	ModalBody,
+	ModalContent,
+	ModalFooter,
+	ModalHeader,
+	ModalTitle,
+	ModalTrigger,
+} from '@/components/modal';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+interface Props {
+	children: React.ReactNode;
+	onUpload: (file: File) => Promise<{ success: boolean }>;
+	aspect?: number; // default 1 (square)
+	maxSizeMB?: number; // default 20
+	acceptedTypes?: string[]; // default jpg, jpeg, png, webp
+}
+
+export function AvatarUploader({
+	children,
+	onUpload,
+	aspect = 1,
+	maxSizeMB = 20,
+	acceptedTypes = ['jpeg', 'jpg', 'png', 'webp'],
+}: Props) {
+	const [crop, setCrop] = React.useState<Point>({ x: 0, y: 0 });
+	const [zoom, setZoom] = React.useState<number>(1);
+
+	const [isPending, setIsPending] = React.useState<boolean>(false);
+	const [photo, setPhoto] = React.useState<{ url: string; file: File | null }>({
+		url: '',
+		file: null,
+	});
+	const [croppedAreaPixels, setCroppedAreaPixels] = React.useState<Area | null>(
+		null,
+	);
+
+	const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const file = e.target.files?.[0];
+		if (!file) return;
+
+		const img_ext = file.name.substring(file.name.lastIndexOf('.') + 1);
+		const validExt = acceptedTypes.includes(img_ext);
+
+		if (!validExt) {
+			throw new Error('Selected file is not a supported image type');
+		} else {
+			if (parseFloat(String(file.size)) / (1024 * 1024) >= maxSizeMB) {
+				throw new Error('Selected image is too large');
+			} else {
+				setPhoto({ url: URL.createObjectURL(file), file });
+			}
+		}
+	};
+
+	const handleCropComplete = (_: Area, croppedAreaPixels: Area) => {
+		setCroppedAreaPixels(croppedAreaPixels);
+	};
+
+	const [open, onOpenChange] = React.useState<boolean>(false);
+
+	const handleUpdate = async () => {
+		if (photo?.file && croppedAreaPixels) {
+			setIsPending(true);
+			try {
+				const croppedImg = await getCroppedImg(photo?.url, croppedAreaPixels);
+				if (!croppedImg || !croppedImg.file) {
+					throw new Error('Failed to crop image');
+				}
+
+				const file = new File(
+					[croppedImg.file],
+					photo.file?.name ?? 'cropped.jpeg',
+					{
+						type: photo.file?.type ?? 'image/jpeg',
+					},
+				);
+
+				await onUpload(file);
+				setPhoto({ url: '', file: null });
+				onOpenChange(false);
+			} catch (error) {
+				throw error instanceof Error
+					? error
+					: new Error('Failed to update image');
+			} finally {
+				setIsPending(false);
+			}
+		} else {
+			throw new Error('No image selected for upload');
+		}
+	};
+
+	return (
+		<Modal
+			open={open}
+			onOpenChange={onOpenChange}
+			drawerProps={{
+				dismissible: photo?.file ? false : true,
+			}}
+		>
+			<ModalTrigger asChild>{children}</ModalTrigger>
+			<ModalContent className="h-max md:max-w-md">
+				<ModalHeader>
+					<ModalTitle>Upload Image</ModalTitle>
+				</ModalHeader>
+				<ModalBody className="space-y-2">
+					<Input
+						disabled={isPending}
+						onChange={handleFileChange}
+						type="file"
+						accept="image/*"
+					/>
+					{photo?.file && (
+						<div className="bg-accent relative aspect-square w-full overflow-hidden rounded-lg">
+							<Cropper
+								image={photo.url}
+								crop={crop}
+								zoom={zoom}
+								aspect={aspect}
+								onCropChange={setCrop}
+								onZoomChange={setZoom}
+								onCropComplete={handleCropComplete}
+								classes={{
+									containerClassName: isPending
+										? 'opacity-80 pointer-events-none'
+										: '',
+								}}
+							/>
+						</div>
+					)}
+				</ModalBody>
+
+				<ModalFooter className="grid w-full grid-cols-2">
+					<Button
+						className="w-full"
+						variant="outline"
+						color="danger"
+						disabled={isPending}
+						onClick={() => onOpenChange(false)}
+					>
+						Cancel
+					</Button>
+
+					<Button
+						className="w-full"
+						type="button"
+						onClick={handleUpdate}
+						disabled={isPending}
+					>
+						{isPending ? 'Uploading...' : 'Update'}
+					</Button>
+				</ModalFooter>
+			</ModalContent>
+		</Modal>
+	);
+}
+
+const createImage = (url: string): Promise<HTMLImageElement> =>
+	new Promise((resolve, reject) => {
+		const image = new Image();
+		image.addEventListener('load', () => resolve(image));
+		image.addEventListener('error', (error) => reject(error));
+		image.setAttribute('crossOrigin', 'anonymous'); // needed to avoid cross-origin issues
+		image.src = url;
+	});
+
+function getRadianAngle(degreeValue: number): number {
+	return (degreeValue * Math.PI) / 180;
+}
+
+/**
+ * Returns the new bounding area of a rotated rectangle.
+ */
+function rotateSize(
+	width: number,
+	height: number,
+	rotation: number,
+): { width: number; height: number } {
+	const rotRad = getRadianAngle(rotation);
+
+	return {
+		width:
+			Math.abs(Math.cos(rotRad) * width) + Math.abs(Math.sin(rotRad) * height),
+		height:
+			Math.abs(Math.sin(rotRad) * width) + Math.abs(Math.cos(rotRad) * height),
+	};
+}
+
+type Flip = {
+	horizontal: boolean;
+	vertical: boolean;
+};
+
+async function getCroppedImg(
+	imageSrc: string,
+	pixelCrop: Area,
+	rotation = 0,
+	flip: Flip = { horizontal: false, vertical: false },
+): Promise<{ url: string; file: Blob | null } | null> {
+	const image = await createImage(imageSrc);
+	const canvas = document.createElement('canvas');
+	const ctx = canvas.getContext('2d');
+
+	if (!ctx) {
+		throw new Error('Failed to create 2D context');
+	}
+
+	const rotRad = getRadianAngle(rotation);
+
+	// calculate bounding box of the rotated image
+	const { width: bBoxWidth, height: bBoxHeight } = rotateSize(
+		image.width,
+		image.height,
+		rotation,
+	);
+
+	// set canvas size to match the bounding box
+	canvas.width = bBoxWidth;
+	canvas.height = bBoxHeight;
+
+	// translate canvas context to a central location to allow rotating and flipping around the center
+	ctx.translate(bBoxWidth / 2, bBoxHeight / 2);
+	ctx.rotate(rotRad);
+	ctx.scale(flip.horizontal ? -1 : 1, flip.vertical ? -1 : 1);
+	ctx.translate(-image.width / 2, -image.height / 2);
+
+	// draw rotated image
+	ctx.drawImage(image, 0, 0);
+
+	// extract cropped image
+	const data = ctx.getImageData(
+		pixelCrop.x,
+		pixelCrop.y,
+		pixelCrop.width,
+		pixelCrop.height,
+	);
+
+	// set canvas width to final desired crop size - this clears context
+	canvas.width = pixelCrop.width;
+	canvas.height = pixelCrop.height;
+
+	// paste cropped image
+	ctx.putImageData(data, 0, 0);
+
+	// return blob + object URL
+	return new Promise((resolve, reject) => {
+		canvas.toBlob((file) => {
+			if (!file) {
+				reject(new Error('Failed to generate cropped image blob'));
+				return;
+			}
+			resolve({
+				url: URL.createObjectURL(file),
+				file,
+			});
+		});
+	});
+}

--- a/frontend/src/components/dialog.tsx
+++ b/frontend/src/components/dialog.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { XIcon } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+function Dialog({
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+	return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+	return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogPortal({
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+	return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogClose({
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+	return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogOverlay({
+	className,
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+	return (
+		<DialogPrimitive.Overlay
+			data-slot="dialog-overlay"
+			className={cn(
+				'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 bg-background/50 fixed inset-0 z-50 backdrop-blur',
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function DialogContent({
+	className,
+	children,
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+	return (
+		<DialogPortal data-slot="dialog-portal">
+			<DialogOverlay />
+			<DialogPrimitive.Content
+				data-slot="dialog-content"
+				className={cn(
+					'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] rounded-lg border shadow-lg duration-200 sm:max-w-lg',
+					className,
+				)}
+				{...props}
+			>
+				{children}
+			</DialogPrimitive.Content>
+		</DialogPortal>
+	);
+}
+
+function DialogBody({ className, ...props }: React.ComponentProps<'div'>) {
+	return (
+		<div
+			data-slot="dialog-body"
+			className={cn('px-4 py-6', className)}
+			{...props}
+		/>
+	);
+}
+
+function DialogHeader({
+	className,
+	children,
+	hideCloseButton = false,
+	...props
+}: React.ComponentProps<'div'> & { hideCloseButton?: boolean }) {
+	return (
+		<div
+			data-slot="dialog-header"
+			className={cn(
+				'bg-muted/30 flex flex-col gap-2 rounded-t-lg border-b p-4 text-center sm:text-left',
+				className,
+			)}
+			{...props}
+		>
+			{children}
+			{!hideCloseButton && (
+				<DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-full opacity-80 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
+					<XIcon />
+					<span className="sr-only">Close</span>
+				</DialogPrimitive.Close>
+			)}
+		</div>
+	);
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
+	return (
+		<div
+			data-slot="dialog-footer"
+			className={cn(
+				'bg-muted/30 flex flex-col gap-2 rounded-b-lg border-t px-4 py-3 sm:flex-row sm:justify-end',
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function DialogTitle({
+	className,
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+	return (
+		<DialogPrimitive.Title
+			data-slot="dialog-title"
+			className={cn('font-heading text-lg leading-none font-medium', className)}
+			{...props}
+		/>
+	);
+}
+
+function DialogDescription({
+	className,
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+	return (
+		<DialogPrimitive.Description
+			data-slot="dialog-description"
+			className={cn('text-muted-foreground text-sm', className)}
+			{...props}
+		/>
+	);
+}
+
+export {
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogBody,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogOverlay,
+	DialogPortal,
+	DialogTitle,
+	DialogTrigger,
+};

--- a/frontend/src/components/drawer.tsx
+++ b/frontend/src/components/drawer.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import * as React from 'react';
+import { Drawer as DrawerPrimitive } from 'vaul';
+import { cn } from '@/lib/utils';
+
+function Drawer({
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+	return <DrawerPrimitive.Root data-slot="drawer" {...props} />;
+}
+
+function DrawerTrigger({
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+	return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />;
+}
+
+function DrawerPortal({
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+	return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />;
+}
+
+function DrawerClose({
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+	return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />;
+}
+
+function DrawerOverlay({
+	className,
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+	return (
+		<DrawerPrimitive.Overlay
+			data-slot="drawer-overlay"
+			className={cn(
+				'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 bg-background/50 fixed inset-0 z-50 backdrop-blur',
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function DrawerContent({
+	className,
+	children,
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+	return (
+		<DrawerPortal data-slot="drawer-portal">
+			<DrawerOverlay />
+			<DrawerPrimitive.Content
+				data-slot="drawer-content"
+				className={cn(
+					'group/drawer-content bg-background fixed z-50 flex h-auto flex-col',
+					'data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-3xl data-[vaul-drawer-direction=top]:border-b',
+					'data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-3xl data-[vaul-drawer-direction=bottom]:border-t',
+					'data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm',
+					'data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:sm:max-w-sm',
+					className,
+				)}
+				{...props}
+			>
+				<div className="bg-muted mx-auto my-2 hidden h-2 w-24 shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+
+				{children}
+			</DrawerPrimitive.Content>
+		</DrawerPortal>
+	);
+}
+
+function DrawerHeader({ className, ...props }: React.ComponentProps<'div'>) {
+	return (
+		<div
+			data-slot="drawer-header"
+			className={cn(
+				'flex w-full flex-col gap-1 rounded-t-3xl border-b px-4 py-2 md:mx-auto md:max-w-md',
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function DrawerBody({ className, ...props }: React.ComponentProps<'div'>) {
+	return (
+		<div
+			data-slot="drawer-body"
+			className={cn('w-full px-4 py-6 md:mx-auto md:max-w-md', className)}
+			{...props}
+		/>
+	);
+}
+
+function DrawerFooter({ className, ...props }: React.ComponentProps<'div'>) {
+	return (
+		<div
+			data-slot="drawer-footer"
+			className={cn(
+				'mt-auto grid w-full gap-2 border-t px-4 py-3 md:mx-auto md:max-w-md',
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function DrawerTitle({
+	className,
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+	return (
+		<DrawerPrimitive.Title
+			data-slot="drawer-title"
+			className={cn('text-foreground font-heading font-medium', className)}
+			{...props}
+		/>
+	);
+}
+
+function DrawerDescription({
+	className,
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+	return (
+		<DrawerPrimitive.Description
+			data-slot="drawer-description"
+			className={cn('text-muted-foreground text-sm', className)}
+			{...props}
+		/>
+	);
+}
+
+export {
+	Drawer,
+	DrawerPortal,
+	DrawerOverlay,
+	DrawerTrigger,
+	DrawerClose,
+	DrawerContent,
+	DrawerHeader,
+	DrawerBody,
+	DrawerFooter,
+	DrawerTitle,
+	DrawerDescription,
+};

--- a/frontend/src/components/editable-avatar.tsx
+++ b/frontend/src/components/editable-avatar.tsx
@@ -1,230 +1,202 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { toast } from "sonner";
-import LucideCamera from "~icons/lucide/camera";
-import LucideUserRound from "~icons/lucide/user-round";
-import { Dialog, DialogContent } from "./animate-ui/components/radix/dialog";
-import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
+import { FileWithPreview } from "@/hooks/use-file-upload"
+import React, { useCallback, useEffect, useRef, useState } from "react"
+import { toast } from "sonner"
 import {
-  Cropper,
-  CropperArea,
-  CropperAreaData,
-  CropperImage,
-  CropperPoint,
-} from "./ui/cropper";
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+} from "./animate-ui/components/radix/dialog"
+import AvatarUpload from "./avatar-upload"
+import {
+	Cropper,
+	CropperArea,
+	CropperAreaData,
+	CropperImage,
+	CropperPoint,
+} from "./ui/cropper"
+import { Slider } from "./ui/slider"
 
 async function createCroppedImage(
-  imageSrc: string,
-  cropData: CropperAreaData,
-  fileName: string
+	imageSrc: string,
+	cropData: CropperAreaData,
+	fileName: string,
 ): Promise<File> {
-  const image = new Image();
-  image.crossOrigin = "anonymous";
+	const image = new Image()
+	image.crossOrigin = "anonymous"
 
-  return new Promise((resolve, reject) => {
-    image.onload = () => {
-      const canvas = document.createElement("canvas");
-      const ctx = canvas.getContext("2d");
+	return new Promise((resolve, reject) => {
+		image.onload = () => {
+			const canvas = document.createElement("canvas")
+			const ctx = canvas.getContext("2d")
 
-      if (!ctx) {
-        reject(new Error("Could not get canvas context"));
-        return;
-      }
+			if (!ctx) {
+				reject(new Error("Could not get canvas context"))
+				return
+			}
 
-      canvas.width = cropData.width;
-      canvas.height = cropData.height;
+			canvas.width = cropData.width
+			canvas.height = cropData.height
 
-      ctx.drawImage(
-        image,
-        cropData.x,
-        cropData.y,
-        cropData.width,
-        cropData.height,
-        0,
-        0,
-        cropData.width,
-        cropData.height
-      );
+			ctx.drawImage(
+				image,
+				cropData.x,
+				cropData.y,
+				cropData.width,
+				cropData.height,
+				0,
+				0,
+				cropData.width,
+				cropData.height,
+			)
 
-      canvas.toBlob((blob) => {
-        if (!blob) {
-          reject(new Error("Canvas is empty"));
-          return;
-        }
+			canvas.toBlob((blob) => {
+				if (!blob) {
+					reject(new Error("Canvas is empty"))
+					return
+				}
 
-        const croppedFile = new File([blob], `cropped-${fileName}`, {
-          type: "image/png",
-        });
-        resolve(croppedFile);
-      }, "image/png");
-    };
+				const croppedFile = new File([blob], `cropped-${fileName}`, {
+					type: "image/png",
+				})
+				resolve(croppedFile)
+			}, "image/png")
+		}
 
-    image.onerror = () => reject(new Error("Failed to load image"));
-    image.src = imageSrc;
-  });
+		image.onerror = () => reject(new Error("Failed to load image"))
+		image.src = imageSrc
+	})
 }
 
 interface Props {
-  src?: string;
-  alt?: string;
-  fallback?: React.ReactNode;
-  onImageChange?: (imageUrl: string) => void;
-  className?: string;
-  size?: number;
+	src?: string
+	alt?: string
+	fallback?: React.ReactNode
+	onImageChange?: (imageUrl: string) => void
+	className?: string
+	size?: number
 }
 
 const EditableAvatar = ({
-  src,
-  alt,
-  fallback,
-  onImageChange,
-  className,
-  size = 128,
+	src,
+	onImageChange,
 }: Props) => {
-  const inputRef = useRef<HTMLInputElement>(null);
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
+	const [isDialogOpen, setIsDialogOpen] = useState(false)
+	const [image, setImage] = useState<FileWithPreview | null>(null)
+	const avatarRef = useRef<{ openFileDialog: () => void }>(null)
 
-  const handleClick = () => {
-    inputRef.current?.click();
-  };
+	const handleFileChange = (file: FileWithPreview | null) => {
+		console.log("Files selected:", file)
+		onImageChange?.(file?.preview || "")
+		if (file) {
+			setImage(file)
+			setIsDialogOpen(true)
+		}
+	}
 
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      const imageUrl = URL.createObjectURL(file);
-      onImageChange?.(imageUrl);
-
-      setIsDialogOpen(true);
-    }
-  };
-
-  // Calculate responsive sizes based on avatar size
-  const fallbackIconSize = Math.max(24, size * 0.375); // 37.5% of avatar size, min 24px
-  const fallbackTextSize = Math.max(16, size * 0.25); // 25% of avatar size, min 16px
-  const cameraIconSize = Math.max(16, size * 0.1875); // 18.75% of avatar size, min 16px
-  const editTextSize = Math.max(10, size * 0.09375); // 9.375% of avatar size, min 10px
-  const overlayGap = Math.max(2, size * 0.03125); // 3.125% of avatar size, min 2px
-
-  return (
-    <>
-      <div
-        className={`relative group cursor-pointer ${className}`}
-        style={{ width: size, height: size }}
-        onClick={handleClick}
-      >
-        <Avatar className="h-full w-full border-2 border-slate-200 dark:border-slate-800 ring-offset-background transition-all group-hover:ring-2 group-hover:ring-slate-400 group-hover:ring-offset-2">
-          <AvatarImage src={src} alt={alt} />
-          <AvatarFallback
-            className="font-semibold"
-            style={{ fontSize: fallbackTextSize }}
-          >
-            {fallback || (
-              <LucideUserRound
-                style={{ width: fallbackIconSize, height: fallbackIconSize }}
-              />
-            )}
-          </AvatarFallback>
-        </Avatar>
-
-        {/* Hover Overlay */}
-        <div className="absolute inset-0 flex items-center justify-center rounded-full bg-black/60 opacity-0 transition-opacity duration-300 group-hover:opacity-100">
-          <div
-            className="flex flex-col items-center text-white"
-            style={{ gap: overlayGap }}
-          >
-            <LucideCamera
-              style={{ width: cameraIconSize, height: cameraIconSize }}
-            />
-            <span className="font-medium" style={{ fontSize: editTextSize }}>
-              Edit
-            </span>
-          </div>
-        </div>
-
-        {/* Hidden File Input */}
-        <input
-          type="file"
-          ref={inputRef}
-          onChange={handleFileChange}
-          className="hidden"
-          accept="image/*"
-        />
-      </div>
-      <CropperDialog open={isDialogOpen} onOpenChange={setIsDialogOpen} />
-    </>
-  );
-};
+	return (
+		<>
+			<AvatarUpload defaultAvatar={src} maxSize={5 * 1024 * 1024} onFileChange={handleFileChange} />
+			<CropperDialog
+				open={isDialogOpen}
+				onOpenChange={setIsDialogOpen}
+				imageUrl={image?.preview}
+				file={image?.file as File}
+			/>
+		</>
+	)
+}
 
 interface FileWithCrop {
-  original: File;
-  cropped?: File;
+	original: File
+	cropped?: File
 }
 
 function CropperDialog({
-  open,
-  onOpenChange,
-  file,
-  imageUrl,
+	open,
+	onOpenChange,
+	file,
+	imageUrl,
 }: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  file?: File;
-  imageUrl?: string;
+	open: boolean
+	onOpenChange: (open: boolean) => void
+	file?: File
+	imageUrl?: string
 }) {
-  const [crop, setCrop] = useState<CropperPoint>({ x: 0, y: 0 });
-  const [croppedArea, setCroppedArea] = useState<CropperAreaData | null>(null);
-  const [zoom, setZoom] = useState(1);
-  const [fileWithCrop, setFileWithCrop] = useState<FileWithCrop | null>(null);
+	const [crop, setCrop] = useState<CropperPoint>({ x: 0, y: 0 })
+	const [croppedArea, setCroppedArea] = useState<CropperAreaData | null>(null)
+	const [zoom, setZoom] = useState(1)
+	const [fileWithCrop, setFileWithCrop] = useState<FileWithCrop | null>(null)
 
-  useEffect(() => {
-    return () => {
-      // Clean up object URLs
-      if (imageUrl) {
-        URL.revokeObjectURL(imageUrl);
-      }
-    };
-  }, [imageUrl]);
+	useEffect(() => {
+		return () => {
+			// Clean up object URLs
+			if (imageUrl) {
+				URL.revokeObjectURL(imageUrl)
+			}
+		}
+	}, [imageUrl])
 
-  const onCropApply = useCallback(async () => {
-    if (!file || !croppedArea || !imageUrl) return;
+	const onCropApply = useCallback(async () => {
+		if (!file || !croppedArea || !imageUrl) return
 
-    try {
-      const croppedFile = await createCroppedImage(
-        imageUrl,
-        croppedArea,
-        file.name
-      );
+		try {
+			const croppedFile = await createCroppedImage(
+				imageUrl,
+				croppedArea,
+				file.name,
+			)
 
-      setFileWithCrop({ original: file, cropped: croppedFile });
+			setFileWithCrop({ original: file, cropped: croppedFile })
 
-      onOpenChange(false);
-    } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : "Failed to crop image"
-      );
-    }
-  }, [file, croppedArea, imageUrl, fileWithCrop, onOpenChange]);
+			onOpenChange(false)
+		} catch (error) {
+			toast.error(
+				error instanceof Error ? error.message : "Failed to crop image",
+			)
+		}
+	}, [file, croppedArea, imageUrl, onOpenChange])
 
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
-        <Cropper
-          aspectRatio={1}
-          crop={crop}
-          zoom={zoom}
-          shape={"circle"}
-          objectFit={"contain"}
-          onCropChange={setCrop}
-          onZoomChange={setZoom}
-          onCropAreaChange={setCroppedArea}
-          onCropComplete={setCroppedArea}
-          className="min-h-72"
-        >
-          <CropperImage src="" alt="Cropper Image" />
-          <CropperArea />
-        </Cropper>
-      </DialogContent>
-    </Dialog>
-  );
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Crop Image</DialogTitle>
+				</DialogHeader>
+				<div className="flex flex-col gap-6">
+					<Cropper
+						aspectRatio={1}
+						crop={crop}
+						zoom={zoom}
+						shape={"circle"}
+						objectFit={"contain"}
+						onCropChange={setCrop}
+						onZoomChange={setZoom}
+						onCropAreaChange={setCroppedArea}
+						onCropComplete={setCroppedArea}
+						className="min-h-[500px]"
+						onCropSizeChange={(cropSize) => {
+							console.log("Crop size:", cropSize)
+						}}
+						onMediaLoaded={(mediaSize) => {
+							console.log("Media size:", mediaSize)
+						}}
+					>
+						<CropperImage src={imageUrl || undefined} alt="Cropper Image" />
+						<CropperArea />
+					</Cropper>
+
+					<Slider
+						value={[zoom]}
+						onValueChange={(value) => setZoom(value[0])}
+						min={1}
+						max={3}
+						step={0.01}
+					/>
+				</div>
+			</DialogContent>
+		</Dialog>
+	)
 }
 
-export default EditableAvatar;
+export default EditableAvatar

--- a/frontend/src/components/modal.tsx
+++ b/frontend/src/components/modal.tsx
@@ -1,0 +1,216 @@
+'use client';
+
+import React from 'react';
+import { cn } from '@/lib/utils';
+import { useIsMobile } from '@/hooks/use-media-query';
+import {
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+	Drawer,
+	DrawerClose,
+	DrawerContent,
+	DrawerDescription,
+	DrawerFooter,
+	DrawerHeader,
+	DrawerTitle,
+	DrawerTrigger,
+} from '@/components/drawer';
+
+const ModalContext = React.createContext<{ isMobile: boolean } | null>(null);
+
+function useContext() {
+	const context = React.useContext(ModalContext);
+	if (!context) {
+		throw new Error('Trigger or Content must be used within <Modal>');
+	}
+	return context;
+}
+
+type ModalProps = {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	defaultOpen?: boolean;
+	children: React.ReactNode;
+	dialogProps?: React.ComponentProps<typeof Dialog>;
+	drawerProps?: React.ComponentProps<typeof Drawer>;
+};
+
+const Modal = ({
+	dialogProps,
+	open,
+	onOpenChange,
+	drawerProps,
+	children,
+}: ModalProps) => {
+	const isMobile = useIsMobile();
+	const Component = isMobile ? Drawer : Dialog;
+	const props = isMobile ? drawerProps : dialogProps;
+
+	return (
+		<ModalContext.Provider value={{ isMobile }}>
+			<Component open={open} onOpenChange={onOpenChange} {...props}>
+				{children}
+			</Component>
+		</ModalContext.Provider>
+	);
+};
+
+type ModalTriggerProps = {
+	className?: string;
+	children: React.ReactNode;
+	asChild?: boolean;
+	drawerProps?: React.ComponentProps<typeof DrawerTrigger>;
+	popoverProps?: React.ComponentProps<typeof DialogTrigger>;
+};
+
+const ModalTrigger = ({
+	className,
+	children,
+	asChild,
+	drawerProps,
+	popoverProps,
+}: ModalTriggerProps) => {
+	const { isMobile } = useContext();
+	const Component = isMobile ? DrawerTrigger : DialogTrigger;
+	const props = isMobile ? drawerProps : popoverProps;
+
+	return (
+		<Component className={className} asChild={asChild} {...props}>
+			{children}
+		</Component>
+	);
+};
+
+type ModalCloseProps = {
+	className?: string;
+	children?: React.ReactNode;
+	asChild?: boolean;
+	drawerProps?: React.ComponentProps<typeof DrawerClose>;
+	popoverProps?: React.ComponentProps<typeof DialogClose>;
+};
+
+const ModalClose = ({
+	className,
+	children,
+	asChild,
+	drawerProps,
+	popoverProps,
+}: ModalCloseProps) => {
+	const { isMobile } = useContext();
+	const Component = isMobile ? DrawerClose : DialogClose;
+	const props = isMobile ? drawerProps : popoverProps;
+
+	return (
+		<Component className={className} asChild={asChild} {...props}>
+			{children}
+		</Component>
+	);
+};
+
+type ModalContentProps = {
+	children: React.ReactNode;
+	className?: string;
+	drawerProps?: React.ComponentProps<typeof DrawerContent>;
+	popoverProps?: React.ComponentProps<typeof DialogContent>;
+};
+
+const ModalContent = ({
+	className,
+	children,
+	drawerProps,
+	popoverProps,
+}: ModalContentProps) => {
+	const { isMobile } = useContext();
+	const Component = isMobile ? DrawerContent : DialogContent;
+	const props = isMobile ? drawerProps : popoverProps;
+
+	return (
+		<Component className={className} {...props}>
+			{children}
+		</Component>
+	);
+};
+
+const ModalHeader = ({ className, ...props }: React.ComponentProps<'div'>) => {
+	const { isMobile } = useContext();
+	const Component = isMobile ? DrawerHeader : DialogHeader;
+
+	return <Component className={className} {...props} />;
+};
+
+type ModalTitleProps = {
+	className?: string;
+	children: React.ReactNode;
+	drawerProps?: React.ComponentProps<typeof DrawerTitle>;
+	popoverProps?: React.ComponentProps<typeof DialogTitle>;
+};
+
+const ModalTitle = ({
+	className,
+	children,
+	drawerProps,
+	popoverProps,
+}: ModalTitleProps) => {
+	const { isMobile } = useContext();
+	const Component = isMobile ? DrawerTitle : DialogTitle;
+	const props = isMobile ? drawerProps : popoverProps;
+
+	return (
+		<Component className={className} {...props}>
+			{children}
+		</Component>
+	);
+};
+
+type ModalDescriptionProps = {
+	className?: string;
+	children: React.ReactNode;
+	drawerProps?: React.ComponentProps<typeof DrawerDescription>;
+	popoverProps?: React.ComponentProps<typeof DialogDescription>;
+};
+
+const ModalDescription = ({
+	className,
+	children,
+	drawerProps,
+	popoverProps,
+}: ModalDescriptionProps) => {
+	const { isMobile } = useContext();
+	const Component = isMobile ? DrawerDescription : DialogDescription;
+	const props = isMobile ? drawerProps : popoverProps;
+
+	return (
+		<Component className={className} {...props}>
+			{children}
+		</Component>
+	);
+};
+
+const ModalBody = ({ className, ...props }: React.ComponentProps<'div'>) => {
+	return <div className={cn('px-4 py-6', className)} {...props} />;
+};
+const ModalFooter = ({ className, ...props }: React.ComponentProps<'div'>) => {
+	const { isMobile } = useContext();
+	const Component = isMobile ? DrawerFooter : DialogFooter;
+	return <Component className={className} {...props} />;
+};
+
+export {
+	Modal,
+	ModalTrigger,
+	ModalClose,
+	ModalContent,
+	ModalDescription,
+	ModalHeader,
+	ModalTitle,
+	ModalBody,
+	ModalFooter,
+};

--- a/frontend/src/hooks/use-media-query.tsx
+++ b/frontend/src/hooks/use-media-query.tsx
@@ -1,0 +1,23 @@
+import * as React from "react"
+
+export function useMediaQuery(query: string) {
+  const [value, setValue] = React.useState(false)
+
+  React.useEffect(() => {
+    function onChange(event: MediaQueryListEvent) {
+      setValue(event.matches)
+    }
+
+    const result = matchMedia(query)
+    result.addEventListener("change", onChange)
+    setValue(result.matches)
+
+    return () => result.removeEventListener("change", onChange)
+  }, [query])
+
+  return value
+}
+
+export function useIsMobile(): boolean {
+  return useMediaQuery("(max-width: 768px)")
+}

--- a/frontend/src/routes/_protected/_settings/account.tsx
+++ b/frontend/src/routes/_protected/_settings/account.tsx
@@ -1,41 +1,40 @@
-import { Button } from "@/components/animate-ui/components/buttons/button"
-import EditableAvatar from "@/components/editable-avatar"
+import { Button } from "@/components/animate-ui/components/buttons/button";
+import EditableAvatar from "@/components/editable-avatar";
 import {
-  Card,
-  CardContent,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card"
-import { useForm } from "@tanstack/react-form"
-import { createFileRoute } from "@tanstack/react-router"
+	Card,
+	CardContent,
+	CardFooter,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { useForm } from "@tanstack/react-form";
+import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_protected/_settings/account")({
-  component: RouteComponent,
-  staticData: {
-    title: "Account Settings",
-  },
+	component: RouteComponent,
+	staticData: {
+		title: "Account Settings",
+	},
 });
 
 function RouteComponent() {
-  const form = useForm({
-    defaultValues: {},
-  });
+	const form = useForm({
+		defaultValues: {},
+	});
 
-  return (
-    <form>
-      <Card>
-        <CardHeader>
-          <CardTitle>
-
-                <EditableAvatar alt="User" fallback={"US"} size={64} />
-          </CardTitle>
-        </CardHeader>
-        <CardContent></CardContent>
-        <CardFooter>
-          <Button>Save Changes</Button>
-        </CardFooter>
-      </Card>
-    </form>
-  );
+	return (
+		<form>
+			<Card>
+				<CardHeader>
+					<CardTitle>
+						<EditableAvatar alt="User" fallback={"US"} size={64} />
+					</CardTitle>
+				</CardHeader>
+				<CardContent></CardContent>
+				<CardFooter>
+					<Button>Save Changes</Button>
+				</CardFooter>
+			</Card>
+		</form>
+	);
 }


### PR DESCRIPTION
drawer/dialog composables

Introduce a new Modal system that abstracts between Drawer (mobile) and Dialog (desktop) implementations using a ModalContext. Add Modal, ModalTrigger, ModalClose, ModalContent, ModalHeader, ModalTitle, ModalDescription, ModalBody and ModalFooter components that pick Drawer or Dialog variants based on the current useIsMobile() media query.

Why:
- Provide a single, consistent API for modals across screen sizes so callers don't need to manage separate Drawer/Dialog imports.
- Centralize responsive behavior and props forwarding (drawerProps / dialogProps / popoverProps) to simplify usage and reduce duplication.
- Enforce usage boundaries by throwing when components are used outside of <Modal> via a context check.

Other:
- Use 'use client' and TypeScript prop typings for safer composition.
- Forward className and children through variant-specific components.